### PR TITLE
Update .gitignore with WiX, NuGet, test, and Jenkins runtime entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ publish/
 *.rar
 *.zip
 
+# NuGet
+*.nupkg
+
 # IDE
 .vs/
 *.user
@@ -16,7 +19,27 @@ publish/
 # Rider
 .idea/
 
+# WiX
+*.wixobj
+*.wixpdb
+*.msi
+*.msm
+*.msp
+*.cab
+
+# Test results
+[Tt]est[Rr]esult*/
+TestResult.xml
+coverage*/
+
 # OS
 Thumbs.db
 Desktop.ini
 .DS_Store
+
+# Jenkins runtime artifacts (local testing)
+agent.jar
+agent.log
+agent*.log
+agent.clef
+remoting/


### PR DESCRIPTION
## Summary
- Add WiX installer artifacts (`.msi`, `.wixobj`, `.wixpdb`, `.cab`)
- Add NuGet `.nupkg` packages
- Add test result and coverage directories
- Add Jenkins runtime artifacts from local testing (`agent.jar`, `agent.log`, `remoting/`)