### PR TITLE
fix(security): suppress false-positive Semgrep path-traversal finding

### DIFF
--- a/src/JenkinsAsService/SecretWriter.cs
+++ b/src/JenkinsAsService/SecretWriter.cs
@@ -47,6 +47,9 @@ public static class SecretWriter
         root[ConfigSectionName] = jenkins;
 
         var options = new JsonSerializerOptions { WriteIndented = true };
+        // basePath is always the trusted application base directory (AppContext.BaseDirectory);
+        // no CLI option sets it and the filename is a constant, so there is no path-traversal vector.
+        // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
         File.WriteAllText(configPath, root.ToJsonString(options), Encoding.UTF8);
     }
 


### PR DESCRIPTION
Semgrep's unsafe-path-combine rule flags File.WriteAllText in SecretWriter.WriteConfig because basePath flows into Path.Combine. The finding is a false positive: basePath is always AppContext.BaseDirectory (no CLI option sets it; the two-arg overload is test-only) and the filename is a compile-time constant, so there is no path-traversal vector. Add a documented, rule-scoped nosemgrep suppression, matching the existing NOSONAR suppression convention in this file.