### PR TITLE
fix(build): make locked restore valid for self-contained publish

### DIFF
--- a/src/JenkinsAsService/JenkinsAsService.csproj
+++ b/src/JenkinsAsService/JenkinsAsService.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <!-- Publish identity declared in-project so the lock file captures the per-RID assets and the
+         single-file ILLink.Tasks reference, keeping RestoreLockedMode valid for both build and publish. -->
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <PublishSingleFile>true</PublishSingleFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>JenkinsAsService</RootNamespace>

--- a/src/JenkinsAsService/packages.lock.json
+++ b/src/JenkinsAsService/packages.lock.json
@@ -44,6 +44,12 @@
           "Microsoft.Extensions.Resilience": "10.7.0"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
+      },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
         "type": "Direct",
         "requested": "[1.16.0, )",
@@ -580,6 +586,36 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      }
+    },
+    "net10.0-windows7.0/win-x64": {
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
+      },
+      "System.ServiceProcess.ServiceController": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "VaYklIT689DthcRzbqt3S8z3GkymiD+US+RLzMFfoPxNIyUxMpXT116cO6rVrKHSuwgdvb35HRKN/PmDmbL+3g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "10.0.9"
+        }
+      }
+    },
+    "net10.0-windows7.0/win-x86": {
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
+      },
+      "System.ServiceProcess.ServiceController": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "VaYklIT689DthcRzbqt3S8z3GkymiD+US+RLzMFfoPxNIyUxMpXT116cO6rVrKHSuwgdvb35HRKN/PmDmbL+3g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "10.0.9"
+        }
       }
     }
   }


### PR DESCRIPTION
The Release "Publish x64/x86" steps failed with NU1004 because the lock file was RID-agnostic and lacked the single-file ILLink.Tasks reference, so RestoreLockedMode could not be satisfied during `dotnet publish --runtime ... --self-contained`.

Rather than weaken the deterministic-build guarantee by dropping RestoreLockedMode on publish, declare the publish identity in the project (<RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers> and <PublishSingleFile>true</PublishSingleFile>) so the regenerated lock file captures the per-RID assets and ILLink.Tasks. One lock file now satisfies locked restore for both plain build and self-contained single-file publish.

Verified locally: locked solution restore, build + 59 tests (no new single-file analyzer warnings), and locked publish for win-x64 and win-x86 (42.3 MB / 38.5 MB self-contained exes).