### PR TITLE
fix(installer): correct WiX v5 authoring so the MSI builds

### DIFF
--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -1,14 +1,6 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
 
-  <!-- ─── Public properties (persisted for custom action) ─── -->
-  <Package>
-    <Property Id="JENKINS_URL" Value="" />
-    <Property Id="JENKINS_SECRET" Value="" Hidden="yes" />
-    <Property Id="JENKINS_AGENT_NAME" Value="" />
-    <Property Id="JENKINS_JAVA_PATH" Value="" />
-    <Property Id="JENKINS_SECRET_MODE" Value="EnvironmentVariable" />
-  </Package>
-
+  <!-- Public properties (JENKINS_*) are declared on the Package in Package.wxs. -->
   <Fragment>
 
     <!-- ════════════════════════════════════════════════════════════════════
@@ -101,11 +93,9 @@
 
         <!-- Warning label for Unprotected mode -->
         <Control Id="WarningText" Type="Text" X="20" Y="205" Width="330" Height="26"
-                 NoPrefix="yes"
-                 Text="WARNING: Unprotected mode stores the secret in plaintext in appsettings.json. Use only for development.">
-          <Condition Action="show">JENKINS_SECRET_MODE = "Unprotected"</Condition>
-          <Condition Action="hide">NOT (JENKINS_SECRET_MODE = "Unprotected")</Condition>
-        </Control>
+                 NoPrefix="yes" Hidden="yes"
+                 ShowCondition="JENKINS_SECRET_MODE = &quot;Unprotected&quot;"
+                 Text="WARNING: Unprotected mode stores the secret in plaintext in appsettings.json. Use only for development." />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -17,6 +17,14 @@
     <Property Id="ARPPRODUCTICON" Value="Logo.ico" />
     <Property Id="ARPHELPLINK" Value="https://github.com/EliorMachlev/JenkinsAsService" />
 
+    <!-- ─── Public properties (set via UI or silent msiexec; consumed by WriteConfig).
+         Secure so they survive the non-elevated → elevated handoff during a managed install. ─── -->
+    <Property Id="JENKINS_URL" Secure="yes" />
+    <Property Id="JENKINS_SECRET" Secure="yes" Hidden="yes" />
+    <Property Id="JENKINS_AGENT_NAME" Secure="yes" />
+    <Property Id="JENKINS_JAVA_PATH" Secure="yes" />
+    <Property Id="JENKINS_SECRET_MODE" Value="EnvironmentVariable" Secure="yes" />
+
     <Feature Id="Main" Title="Jenkins Agent Service" Level="1">
       <ComponentGroupRef Id="PublishOutput" />
       <ComponentRef Id="ServiceComponent" />
@@ -32,7 +40,7 @@
                   Execute="deferred" Impersonate="no" />
 
     <InstallExecuteSequence>
-      <Custom Action="WriteConfig" Before="InstallFinalize">NOT Installed</Custom>
+      <Custom Action="WriteConfig" Before="InstallFinalize" Condition="NOT Installed" />
     </InstallExecuteSequence>
 
   </Package>


### PR DESCRIPTION
The WiX v5 installer never compiled — it carried several v3/v4-era constructs that WiX v5 (WixToolset.Sdk 5.0.2) rejects:

- ConfigDialog.wxs declared a second <Package> just to hold the JENKINS_* properties, which WiX read as a second product missing Name/Manufacturer/ Version. Moved those public properties onto the real <Package> in Package.wxs and marked them Secure (so they survive the non-elevated to elevated handoff during silent installs).
- Control show/hide used v3 <Condition Action="show|hide"> children, removed in v5. Replaced with the v5 Hidden + ShowCondition attribute form.
- <Property Value=""> empty strings are invalid in v5; dropped the empty Value attributes (the properties carry no default).
- <Custom>NOT Installed</Custom> inner-text condition is illegal in v5; moved it to the Condition attribute.

Verified locally: both x64 and x86 MSIs build with 0 errors / 0 warnings.