### PR TITLE
Fix/wix hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,55 @@ jobs:
       - name: Restore
         run: dotnet restore -p:RestoreLockedMode=true
 
-      - name: Build
-        run: dotnet build --no-restore -c Release
-
       - name: Test
-        run: dotnet test --no-build -c Release --verbosity normal
+        run: dotnet test -c Release --verbosity normal
+
+      - name: Publish x64
+        run: >-
+          dotnet publish src/JenkinsAsService
+          --nologo
+          --configuration Release
+          -p:RestoreLockedMode=true
+          --runtime win-x64
+          --self-contained true
+          --output publish/x64/
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:EnableCompressionInSingleFile=true
+          -p:PublishReadyToRun=true
+          -p:OptimizationPreference=Speed
+          -p:UseSharedCompilation=true
+          -p:DebuggerSupport=false
+          -p:MetadataUpdaterSupport=false
+          -p:Deterministic=true
+          -p:DebugType=Embedded
+          -p:DebugSymbols=true
+          /v:q /clp:ErrorsOnly
+
+      - name: Publish x86
+        run: >-
+          dotnet publish src/JenkinsAsService
+          --nologo
+          --configuration Release
+          -p:RestoreLockedMode=true
+          --runtime win-x86
+          --self-contained true
+          --output publish/x86/
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:EnableCompressionInSingleFile=true
+          -p:PublishReadyToRun=true
+          -p:OptimizationPreference=Speed
+          -p:UseSharedCompilation=true
+          -p:DebuggerSupport=false
+          -p:MetadataUpdaterSupport=false
+          -p:Deterministic=true
+          -p:DebugType=Embedded
+          -p:DebugSymbols=true
+          /v:q /clp:ErrorsOnly
+
+      - name: Build MSI x64
+        run: dotnet build src/JenkinsAsService.Installer -c Release -p:RestoreLockedMode=true -p:PublishDir=../../publish/x64/ -p:InstallerPlatform=x64 -p:Version=0.0.0 -o msi/x64/
+
+      - name: Build MSI x86
+        run: dotnet build src/JenkinsAsService.Installer -c Release -p:RestoreLockedMode=true -p:PublishDir=../../publish/x86/ -p:InstallerPlatform=x86 -p:Version=0.0.0 -o msi/x86/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
         include:
         - language: actions
           build-mode: none
+        - language: csharp
+          build-mode: autobuild
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,10 @@ jobs:
           /v:q /clp:ErrorsOnly
 
       - name: Build MSI x64
-        run: dotnet build src/JenkinsAsService.Installer -c Release -p:PublishDir=../../publish/x64/ -p:InstallerPlatform=x64 -p:Version=${{ steps.version.outputs.VERSION }} -o msi/x64/
+        run: dotnet build src/JenkinsAsService.Installer -c Release -p:RestoreLockedMode=true -p:PublishDir=../../publish/x64/ -p:InstallerPlatform=x64 -p:Version=${{ steps.version.outputs.VERSION }} -o msi/x64/
 
       - name: Build MSI x86
-        run: dotnet build src/JenkinsAsService.Installer -c Release -p:PublishDir=../../publish/x86/ -p:InstallerPlatform=x86 -p:Version=${{ steps.version.outputs.VERSION }} -o msi/x86/
+        run: dotnet build src/JenkinsAsService.Installer -c Release -p:RestoreLockedMode=true -p:PublishDir=../../publish/x86/ -p:InstallerPlatform=x86 -p:Version=${{ steps.version.outputs.VERSION }} -o msi/x86/
 
       - name: Rename MSI files
         run: |

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,7 +28,7 @@ JenkinsAsService replaces all of that with a proper Windows Service built on .NE
 - **OpenTelemetry metrics** — opt-in OTLP export: restart counter, SEVERE event counter, .NET runtime metrics
 - **Secret redaction** — agent secrets are scrubbed from all log output
 - **59 unit tests** — xUnit + NSubstitute + FluentAssertions, CI on every push
-- **6 security scans** — CodeQL, Semgrep, Gitleaks, PSScriptAnalyzer, Dependency Review, Trivy
+- **6 security scans** — CodeQL (C# + Actions YAML), Semgrep, Gitleaks, PSScriptAnalyzer, Dependency Review, Trivy
 - **Single-file deploy** — self-contained `.exe` with R2R, compression, and embedded PDB symbols
 - **Dual-arch releases** — x64 + x86 MSI installers, 7z/RAR archives, SHA256 checksums
 
@@ -230,7 +230,7 @@ dotnet build src/JenkinsAsService.Installer -c Release `
 - Secrets encrypted at rest (DPAPI/CredMgr) and redacted from all logs
 - Deterministic builds with locked NuGet restore and embedded PDB symbols
 - 59 unit tests run on every push and PR
-- 6 security scans: **CodeQL** (SAST), **Semgrep** (pattern SAST + secrets), **Gitleaks** (git history), **PSScriptAnalyzer** (PowerShell), **Dependency Review** (CVE gate), **Trivy** (SCA, NVD + GHSA + OSV)
+- 6 security scans: **CodeQL** (C# SAST + Actions YAML), **Semgrep** (pattern SAST + secrets), **Gitleaks** (git history), **PSScriptAnalyzer** (PowerShell), **Dependency Review** (CVE gate), **Trivy** (SCA, NVD + GHSA + OSV)
 - Automated dual-arch release pipeline with SHA256 checksums
 
 See [Security Policy](Security.md) for vulnerability reporting.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -221,7 +221,7 @@ dotnet publish src/JenkinsAsService `
 
 # Optional: build WiX v5 MSI
 dotnet build src/JenkinsAsService.Installer -c Release `
-    -p:PublishDir=../../publish/x64/ -p:Version=1.0.0
+    -p:RestoreLockedMode=true -p:PublishDir=../../publish/x64/ -p:Version=1.0.0
 ```
 
 ## Security

--- a/docs/ci-cd.html
+++ b/docs/ci-cd.html
@@ -66,12 +66,23 @@
 
     <h3 id="release">Release (<code>.github/workflows/release.yml</code>)</h3>
     <ul>
-      <li><strong>Purpose:</strong> Automated dual-architecture release on version tags</li>
-      <li><strong>Trigger:</strong> Push tag matching <code>v*</code></li>
+      <li><strong>Purpose:</strong> Automated dual-architecture release</li>
+      <li><strong>Triggers:</strong>
+        <ul>
+          <li><strong>Tag push</strong> &mdash; any tag matching <code>v*</code> (e.g. <code>v1.0.5</code>). Version is taken verbatim from the tag name.</li>
+          <li><strong>Manual (<code>workflow_dispatch</code>)</strong> &mdash; optional <code>version</code> input:
+            <ul>
+              <li>If provided (e.g. <code>1.05</code>): used verbatim as the release version.</li>
+              <li>If omitted: auto-bumps the latest published non-prerelease release by +1 on the final segment, preserving zero-padding (e.g. <code>1.03</code> &rarr; <code>1.04</code>).</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
       <li><strong>Runner:</strong> <code>windows-latest</code></li>
       <li><strong>Steps:</strong>
         <ol>
           <li>Setup .NET 10 &rarr; <code>dotnet test</code></li>
+          <li>Resolve version (from tag, explicit input, or auto-bump via <code>gh api</code>)</li>
           <li>Optimized publish for <strong>win-x64</strong> and <strong>win-x86</strong> (R2R, compression, embedded PDB, deterministic, speed-optimized, locked restore)</li>
           <li>Build MSI installers for both architectures via <strong>WiX v5</strong></li>
           <li>Create <code>.7z</code> archives (LZMA2, max compression) via 7-Zip</li>
@@ -139,15 +150,25 @@
     <ul>
       <li><strong>Trigger:</strong> <code>workflow_call</code> with inputs <code>scan-type</code> (default: <code>fs</code>) and <code>scan-ref</code> (default: <code>.</code>)</li>
       <li><strong>Steps:</strong> checkout &rarr; trivy &rarr; upload-sarif (<code>if: always()</code>)</li>
-      <li><strong>Versioning:</strong> <code>actions/checkout@v6</code>, <code>github/codeql-action/upload-sarif@v4</code>, <code>aquasecurity/trivy-action@v0.36.0</code></li>
+      <li><strong>Versioning:</strong> <code>actions/checkout@v7</code>, <code>github/codeql-action/upload-sarif@v4</code>, <code>aquasecurity/trivy-action@v0.36.0</code></li>
     </ul>
 
     <h2 id="dependabot">Dependabot (<code>.github/dependabot.yml</code>)</h2>
 
-    <p>Weekly automated PRs for:</p>
+    <p>Weekly automated PRs using <strong>grouped updates</strong> to reduce noise:</p>
+
+    <h3 id="dependabot-nuget">NuGet (<code>nuget</code>)</h3>
     <ul>
-      <li><code>nuget</code> &mdash; NuGet package updates</li>
-      <li><code>github-actions</code> &mdash; Action version bumps</li>
+      <li><code>serilog</code> &mdash; all <code>Serilog.*</code> packages in one PR</li>
+      <li><code>microsoft-extensions</code> &mdash; all <code>Microsoft.Extensions.*</code> packages in one PR</li>
+      <li><code>opentelemetry</code> &mdash; all <code>OpenTelemetry*</code> packages in one PR</li>
+      <li><code>xunit</code> &mdash; all <code>xunit*</code> packages in one PR</li>
+      <li><code>test-tooling</code> &mdash; <code>Microsoft.NET.Test.Sdk</code>, <code>coverlet.*</code>, <code>NSubstitute</code>, <code>FluentAssertions</code> in one PR</li>
+    </ul>
+
+    <h3 id="dependabot-actions">GitHub Actions (<code>github-actions</code>)</h3>
+    <ul>
+      <li>All action version bumps grouped into a single weekly PR</li>
     </ul>
 
     <h2 id="security-scanning-stack-summary">Security Scanning Stack Summary</h2>
@@ -230,7 +251,7 @@
         <tbody>
           <tr>
             <td><code>actions/checkout</code></td>
-            <td><code>@v6</code></td>
+            <td><code>@v7</code></td>
           </tr>
           <tr>
             <td><code>actions/setup-dotnet</code></td>

--- a/docs/ci-cd.html
+++ b/docs/ci-cd.html
@@ -97,11 +97,14 @@
 
     <h3 id="codeql">CodeQL Advanced (<code>.github/workflows/codeql.yml</code>)</h3>
     <ul>
-      <li><strong>Purpose:</strong> Vulnerability analysis of GitHub Actions workflow files (<code>language: actions</code>)</li>
+      <li><strong>Purpose:</strong> Vulnerability analysis across two language targets in a matrix:</li>
+      <ul>
+        <li><code>language: actions</code> (<code>build-mode: none</code>) &mdash; GitHub Actions workflow YAML files</li>
+        <li><code>language: csharp</code> (<code>build-mode: autobuild</code>) &mdash; C# source code</li>
+      </ul>
       <li><strong>Tool:</strong> <a href="https://github.com/github/codeql-action">github/codeql-action</a></li>
       <li><strong>Trigger:</strong> Push/PR to <code>main</code>, weekly schedule (Tuesdays 16:35 UTC)</li>
-      <li><strong>Output:</strong> SARIF uploaded to GitHub Security &rarr; Code scanning results</li>
-      <li><strong>Note:</strong> The matrix only contains <code>language: actions</code>. C# code scanning results visible in the Security tab come from GitHub's native default-setup CodeQL, which runs independently of this workflow.</li>
+      <li><strong>Output:</strong> SARIF uploaded to GitHub Security &rarr; Code scanning results (one entry per language)</li>
     </ul>
 
     <h3 id="psscriptanalyzer">PSScriptAnalyzer (<code>.github/workflows/powershell.yml</code>)</h3>
@@ -186,16 +189,10 @@
         </thead>
         <tbody>
           <tr>
-            <td>SAST (Actions)</td>
+            <td>SAST (Actions + C#)</td>
             <td>CodeQL Advanced</td>
             <td>Push/PR/weekly</td>
-            <td>GitHub Actions workflow vulnerabilities (<code>language: actions</code>)</td>
-          </tr>
-          <tr>
-            <td>SAST (C# &mdash; native)</td>
-            <td>CodeQL (default setup)</td>
-            <td>GitHub-managed</td>
-            <td>C# source code vulnerabilities; results in Security &rarr; Code scanning</td>
+            <td>GitHub Actions workflow YAML (<code>language: actions</code>) and C# source (<code>language: csharp</code>, autobuild)</td>
           </tr>
           <tr>
             <td>SAST (patterns)</td>
@@ -253,10 +250,9 @@
 
     <p>Two workflows upload SARIF and contribute findings to GitHub Security &rarr; Code scanning:</p>
     <ul>
-      <li><strong>CodeQL Advanced</strong> &mdash; <code>language: actions</code> analysis of GitHub Actions workflow YAML files</li>
+      <li><strong>CodeQL Advanced</strong> &mdash; two matrix jobs: <code>language: actions</code> (workflow YAML) and <code>language: csharp</code> (C# source via autobuild)</li>
       <li><strong>PSScriptAnalyzer</strong> &mdash; static analysis of PowerShell scripts embedded in workflow <code>run:</code> steps</li>
     </ul>
-    <p>C# results visible in Code scanning come from GitHub&rsquo;s <strong>native default-setup CodeQL</strong>, which is a GitHub-managed feature separate from the custom <code>codeql.yml</code> workflow.</p>
 
     <h2 id="nuget-dependency-submission">NuGet Dependency Submission</h2>
 

--- a/docs/ci-cd.html
+++ b/docs/ci-cd.html
@@ -95,37 +95,38 @@
       <li><strong>Naming:</strong> <code>JenkinsAsService_&lt;version&gt;_&lt;arch&gt;.&lt;ext&gt;</code></li>
     </ul>
 
-    <h3 id="codeql">CodeQL (<code>.github/workflows/codeql.yml</code>)</h3>
+    <h3 id="codeql">CodeQL Advanced (<code>.github/workflows/codeql.yml</code>)</h3>
     <ul>
-      <li><strong>Purpose:</strong> Source code vulnerability analysis (C#)</li>
+      <li><strong>Purpose:</strong> Vulnerability analysis of GitHub Actions workflow files (<code>language: actions</code>)</li>
       <li><strong>Tool:</strong> <a href="https://github.com/github/codeql-action">github/codeql-action</a></li>
-      <li><strong>Trigger:</strong> Push/PR to <code>main</code>, weekly schedule</li>
-      <li><strong>Output:</strong> Findings in GitHub Security tab</li>
+      <li><strong>Trigger:</strong> Push/PR to <code>main</code>, weekly schedule (Tuesdays 16:35 UTC)</li>
+      <li><strong>Output:</strong> SARIF uploaded to GitHub Security &rarr; Code scanning results</li>
+      <li><strong>Note:</strong> The matrix only contains <code>language: actions</code>. C# code scanning results visible in the Security tab come from GitHub's native default-setup CodeQL, which runs independently of this workflow.</li>
     </ul>
 
     <h3 id="psscriptanalyzer">PSScriptAnalyzer (<code>.github/workflows/powershell.yml</code>)</h3>
     <ul>
       <li><strong>Purpose:</strong> Static analysis of PowerShell code (full ruleset)</li>
       <li><strong>Tool:</strong> <a href="https://github.com/microsoft/action-psscriptanalyzer">microsoft/psscriptanalyzer-action</a></li>
-      <li><strong>Output:</strong> SARIF uploaded to GitHub Security tab</li>
-      <li><strong>Schedule:</strong> Sundays at 23:23 UTC</li>
+      <li><strong>Trigger:</strong> Push/PR to <code>main</code>, Sundays at 23:23 UTC, <code>workflow_dispatch</code> (manual)</li>
+      <li><strong>Output:</strong> SARIF uploaded to GitHub Security &rarr; Code scanning results</li>
     </ul>
 
     <h3 id="semgrep">Semgrep (<code>.github/workflows/semgrep.yml</code>)</h3>
     <ul>
       <li><strong>Purpose:</strong> Pattern-based SAST &mdash; vulnerable code patterns, deprecated APIs, common weaknesses</li>
       <li><strong>Tool:</strong> <a href="https://github.com/semgrep/semgrep-action">semgrep/semgrep-action@v1</a></li>
+      <li><strong>Trigger:</strong> Push/PR to <code>main</code>, Sundays at 04:38 UTC</li>
       <li><strong>Rules:</strong> <code>p/default</code> + <code>p/csharp</code> + <code>p/secrets</code> (community rulesets, no token required)</li>
       <li><strong>Output:</strong> SARIF uploaded to GitHub Security tab</li>
-      <li><strong>Schedule:</strong> Sundays at 04:38 UTC</li>
     </ul>
 
     <h3 id="gitleaks">Gitleaks (<code>.github/workflows/gitleaks.yml</code>)</h3>
     <ul>
       <li><strong>Purpose:</strong> Secret and credential scanning across full git history</li>
       <li><strong>Tool:</strong> <a href="https://github.com/gitleaks/gitleaks-action">gitleaks/gitleaks-action@v3.0.0</a></li>
+      <li><strong>Trigger:</strong> Push/PR to <code>main</code>, Sundays at 05:00 UTC</li>
       <li><strong>Coverage:</strong> <code>fetch-depth: 0</code> &mdash; scans all commits</li>
-      <li><strong>Schedule:</strong> Sundays at 05:00 UTC</li>
     </ul>
 
     <h3 id="dependency-review">Dependency Review (<code>.github/workflows/dependency-review.yml</code>)</h3>
@@ -185,10 +186,16 @@
         </thead>
         <tbody>
           <tr>
-            <td>SAST (C#)</td>
-            <td>CodeQL</td>
+            <td>SAST (Actions)</td>
+            <td>CodeQL Advanced</td>
             <td>Push/PR/weekly</td>
-            <td>Source code vulnerabilities</td>
+            <td>GitHub Actions workflow vulnerabilities (<code>language: actions</code>)</td>
+          </tr>
+          <tr>
+            <td>SAST (C# &mdash; native)</td>
+            <td>CodeQL (default setup)</td>
+            <td>GitHub-managed</td>
+            <td>C# source code vulnerabilities; results in Security &rarr; Code scanning</td>
           </tr>
           <tr>
             <td>SAST (patterns)</td>
@@ -205,8 +212,8 @@
           <tr>
             <td>SAST (PS)</td>
             <td>PSScriptAnalyzer</td>
-            <td>Push/PR/weekly</td>
-            <td>PowerShell scripts</td>
+            <td>Push/PR/weekly/manual</td>
+            <td>PowerShell scripts; SARIF in Security &rarr; Code scanning</td>
           </tr>
           <tr>
             <td>SCA (PR gate)</td>
@@ -218,7 +225,13 @@
             <td>SCA (full)</td>
             <td>Trivy</td>
             <td>Push + weekly</td>
-            <td>All NuGet deps, multi-DB</td>
+            <td>All NuGet deps, multi-DB (NVD + GHSA + OSV)</td>
+          </tr>
+          <tr>
+            <td>Dependency graph</td>
+            <td>GitHub native (dynamic)</td>
+            <td>Always (platform-managed)</td>
+            <td>NuGet dependency submission via GitHub&rsquo;s automatic <code>submit-nuget</code> workflow</td>
           </tr>
           <tr>
             <td>Dependabot alerts</td>
@@ -229,12 +242,25 @@
           <tr>
             <td>Dependabot updates</td>
             <td>GitHub native</td>
-            <td>Weekly PRs</td>
-            <td>NuGet + GitHub Actions version bumps</td>
+            <td>Weekly PRs (grouped)</td>
+            <td>NuGet + GitHub Actions version bumps, organized by package family</td>
           </tr>
         </tbody>
       </table>
     </div>
+
+    <h2 id="code-scanning-results">Code Scanning Results (Security Tab)</h2>
+
+    <p>Two workflows upload SARIF and contribute findings to GitHub Security &rarr; Code scanning:</p>
+    <ul>
+      <li><strong>CodeQL Advanced</strong> &mdash; <code>language: actions</code> analysis of GitHub Actions workflow YAML files</li>
+      <li><strong>PSScriptAnalyzer</strong> &mdash; static analysis of PowerShell scripts embedded in workflow <code>run:</code> steps</li>
+    </ul>
+    <p>C# results visible in Code scanning come from GitHub&rsquo;s <strong>native default-setup CodeQL</strong>, which is a GitHub-managed feature separate from the custom <code>codeql.yml</code> workflow.</p>
+
+    <h2 id="nuget-dependency-submission">NuGet Dependency Submission</h2>
+
+    <p>GitHub automatically runs a platform-managed <strong><code>submit-nuget</code></strong> workflow (listed as <em>dynamic</em> in the Actions tab) that submits the resolved NuGet dependency graph to GitHub&rsquo;s dependency graph API. This is not a workflow file in the repository &mdash; GitHub triggers it when a <code>.csproj</code> or <code>packages.lock.json</code> is present. It powers Dependabot alerts and the dependency graph view for this repo.</p>
 
     <h2 id="action-versioning-policy">Action Versioning Policy</h2>
 

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -55,6 +55,8 @@
     <h2 id="build-toolchain">Build Toolchain</h2>
     <p>The project uses the <strong>.NET 10 SDK</strong> with the <code>Microsoft.NET.Sdk.Worker</code> project type. Deterministic builds with locked NuGet restore (<code>packages.lock.json</code>).</p>
 
+    <p><strong>Central Package Management (CPM)</strong> is enabled via <code>Directory.Packages.props</code> at the repo root. All NuGet version numbers are declared there &mdash; individual <code>.csproj</code> files reference packages without version attributes. Dependabot targets the CPM file directly, producing grouped PRs per package family.</p>
+
     <h2 id="build-publish">Build &amp; Publish</h2>
     <pre data-lang="powershell"><code># Restore (locked mode — requires packages.lock.json)
 dotnet restore -p:RestoreLockedMode=true
@@ -279,7 +281,7 @@ dotnet build src/JenkinsAsService.Installer -c Release -p:PublishDir=../../publi
 
     <div class="callout callout--note">
       <div class="callout-title">Note</div>
-      <p>All versions are pinned (no floating ranges). Both projects include <code>packages.lock.json</code> for deterministic restores via <code>RestoreLockedMode=true</code>.</p>
+      <p>All versions are pinned (no floating ranges) and centrally managed in <code>Directory.Packages.props</code>. Both projects include <code>packages.lock.json</code> for deterministic, hash-verified restores via <code>RestoreLockedMode=true</code>.</p>
     </div>
 
     <h2 id="msi-installer">MSI Installer</h2>

--- a/docs/search-index.json
+++ b/docs/search-index.json
@@ -33,13 +33,13 @@
     "id": "installation",
     "title": "Installation",
     "url": "installation.html",
-    "keywords": ["installation", "install", "setup", "deploy", "windows", "service", "sc", "publish", "prerequisites", "requirements", "powershell"]
+    "keywords": ["installation", "install", "setup", "deploy", "windows", "service", "sc", "publish", "prerequisites", "requirements", "powershell", "central package management", "cpm", "directory.packages.props", "nuget", "msi", "wix"]
   },
   {
     "id": "ci-cd",
     "title": "CI/CD & Security",
     "url": "ci-cd.html",
-    "keywords": ["ci", "cd", "cicd", "pipeline", "github actions", "security", "scanning", "semgrep", "gitleaks", "trivy", "psscriptanalyzer", "sast", "secrets", "vulnerabilities"]
+    "keywords": ["ci", "cd", "cicd", "pipeline", "github actions", "security", "scanning", "semgrep", "gitleaks", "trivy", "psscriptanalyzer", "sast", "secrets", "vulnerabilities", "release", "workflow dispatch", "manual release", "auto bump", "dependabot", "grouped updates"]
   },
   {
     "id": "troubleshooting",

--- a/src/JenkinsAsService.Installer/JenkinsAsService.Installer.wixproj
+++ b/src/JenkinsAsService.Installer/JenkinsAsService.Installer.wixproj
@@ -1,8 +1,9 @@
 <Project Sdk="WixToolset.Sdk/5.0.2">
 
   <PropertyGroup>
-    <!-- WiX uses floating 5.* versions managed inline; keep it out of central package management. -->
+    <!-- WiX extensions are pinned to the SDK version and locked for deterministic, secure restores. -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <OutputType>Package</OutputType>
     <InstallerPlatform>x64</InstallerPlatform>
     <!-- Set via -p:PublishDir=... from the build script after dotnet publish -->
@@ -15,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="5.*" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="5.*" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.2" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/JenkinsAsService.Installer/packages.lock.json
+++ b/src/JenkinsAsService.Installer/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    "native,Version=v0.0": {
+      "WixToolset.UI.wixext": {
+        "type": "Direct",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "BP2IonPN5/0csF1esRb1A834aknY+wO421hXOP+Ix730YxQvSXgk6kV9uFnVHlrVMXxunXpuqEf2qqOQuvWoQw=="
+      },
+      "WixToolset.Util.wixext": {
+        "type": "Direct",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "sr3GNWr9bTcuALh58lvzLQrwWTuwcQTHkHXhPwFHNrg3GlUrY9arm3fRLWGo3RN739NhUrFEB8dguVsO/gVb9Q=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **WiX v5 syntax fix** — correct authoring in \`Package.wxs\` and \`ConfigDialog.wxs\` so the MSI actually builds under WiX v5
- **WiX hardening** — pin \`WixToolset.UI.wixext\` and \`WixToolset.Util.wixext\` from floating \`5.*\` to \`5.0.2\`; add \`RestorePackagesWithLockFile=true\` and a committed \`packages.lock.json\` with SHA256 content hashes; enforce \`-p:RestoreLockedMode=true\` on both MSI build steps in \`release.yml\` and the README example
- **CodeQL C# analysis** — add \`language: csharp\` (\`build-mode: autobuild\`) to the CodeQL Advanced matrix so C# source is scanned by our own workflow, not just GitHub native default setup
- **Docs sync (GitHub Pages + README)** — bring all docs up to date with changes merged since June 17th: manual release trigger with auto-bump, \`actions/checkout\` v6→v7, Dependabot grouped updates, CPM (\`Directory.Packages.props\`), correct CodeQL matrix, missing \`pull_request\` triggers for Semgrep/Gitleaks/PSScriptAnalyzer, new Code Scanning Results and NuGet Dependency Submission sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)