### PR TITLE
feat(installer): full config coverage in the MSI wizard — advanced options, merge CLI, pre-start config write

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Add tests alongside new logic; run `dotnet test -c Release` and confirm green be
 - Default secret mode is **`Dpapi`** (encrypted at rest, machine-scoped) — deliberately **not** the world-readable machine env var. The Security Options radio group lists DPAPI (recommended) → TPM (strongest) → Credential Manager → Environment Variable → Unprotected.
 - The install-time secret is passed on the `WriteConfig` deferred CA command line — an accepted MSI trade-off (EXE custom actions get no `CustomActionData`); mitigated by `Hidden="yes"` + `Impersonate="no"` (runs as SYSTEM). Scripted installs that must avoid even a verbose MSI log should call `update-secret` directly with the secret-env/secret-file input options.
 - Default identity is the virtual account `NT SERVICE\Jenkins`. Runtime data dir is set by a second CA (`--set-data-dir`) because folding it into the main command would exceed the MSI 255-char CA limit.
+- Optional settings are collected across the two config pages plus an **Advanced Options** page and applied by three deferred `update-secret --merge` custom actions (`WriteAdvanced1/2/3`), split only to stay under the MSI 255-char CA limit. They run after `WriteConfig` and before `StartServices`, so the full config exists before the service launches.
 - XML comments must not contain `--` (WIX0104); validate `.wxs` well-formedness after edits.
 
 ## CI/CD & Security Scans

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -51,6 +51,7 @@
 
     <h2 id="configuration-file">Configuration File</h2>
     <p>The service reads its settings from <code>appsettings.json</code>, located in the same directory as the executable. The <code>Jenkins</code> section is grouped into topic sub-sections &mdash; <code>Connection</code>, <code>Secret</code>, <code>Agent</code>, <code>Hardening</code>, <code>Logging</code>, and <code>Recovery</code>. Settings below are written as <code>Section:Key</code>.</p>
+    <p>The MSI installer wizard now collects every setting below across the <code>JenkinsConfigDlg</code>, <code>SecurityOptionsDlg</code>, and a new <strong>Advanced Options</strong> page (<code>AdvancedOptionsDlg</code>) &mdash; including <code>Connection:Method</code> and <code>Connection:ControllerCertThumbprint</code>, which previously required a manual edit of <code>appsettings.json</code> after install. Fields left untouched keep the same defaults as before.</p>
 
     <h2 id="settings-reference">Settings Reference</h2>
     <div class="table-wrap">

--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -18,32 +18,44 @@
 
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
                  TabSkip="no" Text="WixUI_Bmp_Banner" />
-
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
 
-        <!-- Jenkins URL -->
-        <Control Id="UrlLabel" Type="Text" X="20" Y="60" Width="120" Height="13"
-                 NoPrefix="yes" Text="Jenkins URL (with port):" />
-        <Control Id="UrlEdit" Type="Edit" X="20" Y="74" Width="330" Height="18"
-                 Property="JENKINS_URL" />
+        <!-- Row 1: Jenkins URL (required) -->
+        <Control Id="UrlLabel" Type="Text" X="15" Y="62" Width="115" Height="13" NoPrefix="yes"
+                 Text="Jenkins URL (with port):" />
+        <Control Id="UrlEdit" Type="Edit" X="135" Y="60" Width="220" Height="16" Property="JENKINS_URL" />
 
-        <!-- Agent Secret -->
-        <Control Id="SecretLabel" Type="Text" X="20" Y="100" Width="120" Height="13"
-                 NoPrefix="yes" Text="Agent Secret:" />
-        <Control Id="SecretEdit" Type="MaskedEdit" X="20" Y="114" Width="330" Height="18"
-                 Property="JENKINS_SECRET" />
+        <!-- Row 2: Agent Secret (required) -->
+        <Control Id="SecretLabel" Type="Text" X="15" Y="90" Width="115" Height="13" NoPrefix="yes"
+                 Text="Agent Secret:" />
+        <Control Id="SecretEdit" Type="MaskedEdit" X="135" Y="88" Width="220" Height="16" Property="JENKINS_SECRET" />
 
-        <!-- Agent Name -->
-        <Control Id="NameLabel" Type="Text" X="20" Y="140" Width="200" Height="13"
-                 NoPrefix="yes" Text="Agent Name (blank = hostname):" />
-        <Control Id="NameEdit" Type="Edit" X="20" Y="154" Width="330" Height="18"
-                 Property="JENKINS_AGENT_NAME" />
+        <!-- Row 3: Connection Method -->
+        <Control Id="MethodLabel" Type="Text" X="15" Y="118" Width="115" Height="13" NoPrefix="yes"
+                 Text="Connection Method:" />
+        <Control Id="MethodGroup" Type="RadioButtonGroup" X="133" Y="116" Width="222" Height="16"
+                 Property="JENKINS_METHOD">
+          <RadioButtonGroup Property="JENKINS_METHOD">
+            <RadioButton Value="Auto" X="0" Y="0" Width="52" Height="16" Text="Auto" />
+            <RadioButton Value="WebSocket" X="54" Y="0" Width="88" Height="16" Text="WebSocket" />
+            <RadioButton Value="Https" X="146" Y="0" Width="70" Height="16" Text="Https" />
+          </RadioButtonGroup>
+        </Control>
 
-        <!-- Java Path -->
-        <Control Id="JavaLabel" Type="Text" X="20" Y="180" Width="250" Height="13"
-                 NoPrefix="yes" Text="Java Path (blank = JAVA_HOME):" />
-        <Control Id="JavaEdit" Type="Edit" X="20" Y="194" Width="330" Height="18"
-                 Property="JENKINS_JAVA_PATH" />
+        <!-- Row 4: Controller cert thumbprint -->
+        <Control Id="ThumbLabel" Type="Text" X="15" Y="146" Width="115" Height="13" NoPrefix="yes"
+                 Text="Cert Thumbprint (opt):" />
+        <Control Id="ThumbEdit" Type="Edit" X="135" Y="144" Width="220" Height="16" Property="JENKINS_THUMBPRINT" />
+
+        <!-- Row 5: Agent name -->
+        <Control Id="NameLabel" Type="Text" X="15" Y="174" Width="115" Height="13" NoPrefix="yes"
+                 Text="Agent Name (opt):" />
+        <Control Id="NameEdit" Type="Edit" X="135" Y="172" Width="220" Height="16" Property="JENKINS_AGENT_NAME" />
+
+        <!-- Row 6: Java path -->
+        <Control Id="JavaLabel" Type="Text" X="15" Y="202" Width="115" Height="13" NoPrefix="yes"
+                 Text="Java Path (opt):" />
+        <Control Id="JavaEdit" Type="Edit" X="135" Y="200" Width="220" Height="16" Property="JENKINS_JAVA_PATH" />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 
@@ -51,7 +63,10 @@
           <Publish Event="NewDialog" Value="InstallDirDlg" />
         </Control>
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="&amp;Next">
-          <Publish Event="NewDialog" Value="SecurityOptionsDlg" />
+          <Publish Event="SpawnDialog" Value="RequiredFieldDlg" Order="1"
+                   Condition="NOT JENKINS_URL OR NOT JENKINS_SECRET" />
+          <Publish Event="NewDialog" Value="SecurityOptionsDlg" Order="2"
+                   Condition="JENKINS_URL AND JENKINS_SECRET" />
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="Cancel">
           <Publish Event="SpawnDialog" Value="CancelDlg" />
@@ -111,6 +126,16 @@
           <Publish Event="SpawnDialog" Value="CancelDlg" />
         </Control>
 
+      </Dialog>
+
+      <!-- Modal shown when a required field is blank on the config page. -->
+      <Dialog Id="RequiredFieldDlg" Width="260" Height="85" Title="[ProductName] Setup" NoMinimize="yes">
+        <Control Id="Text" Type="Text" X="15" Y="15" Width="230" Height="40" NoPrefix="yes"
+                 Text="Jenkins URL and Agent Secret are both required. Please fill them in before continuing." />
+        <Control Id="OK" Type="PushButton" X="100" Y="60" Width="56" Height="17" Default="yes" Cancel="yes"
+                 Text="OK">
+          <Publish Event="EndDialog" Value="Return" />
+        </Control>
       </Dialog>
 
       <!-- ─── Wire into WixUI_InstallDir sequence ─── -->

--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -91,28 +91,42 @@
 
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
 
-        <!-- Radio button group -->
-        <Control Id="SecretModeGroup" Type="RadioButtonGroup" X="20" Y="60" Width="330" Height="140"
+        <Control Id="SecretModeGroup" Type="RadioButtonGroup" X="20" Y="54" Width="330" Height="120"
                  Property="JENKINS_SECRET_MODE">
           <RadioButtonGroup Property="JENKINS_SECRET_MODE">
-            <RadioButton Value="Dpapi" X="0" Y="0" Width="330" Height="18"
+            <RadioButton Value="Dpapi" X="0" Y="0" Width="330" Height="17"
                          Text="DPAPI — machine-scoped encryption at rest (recommended)" />
-            <RadioButton Value="Tpm" X="0" Y="28" Width="330" Height="18"
+            <RadioButton Value="Tpm" X="0" Y="24" Width="330" Height="17"
                          Text="TPM 2.0 — hardware-backed, non-exportable key (strongest; requires TPM)" />
-            <RadioButton Value="CredentialManager" X="0" Y="56" Width="330" Height="18"
+            <RadioButton Value="CredentialManager" X="0" Y="48" Width="330" Height="17"
                          Text="Windows Credential Manager — store in OS credential vault" />
-            <RadioButton Value="EnvironmentVariable" X="0" Y="84" Width="330" Height="18"
+            <RadioButton Value="EnvironmentVariable" X="0" Y="72" Width="330" Height="17"
                          Text="Environment Variable — machine var, readable by all local users" />
-            <RadioButton Value="Unprotected" X="0" Y="112" Width="330" Height="18"
+            <RadioButton Value="Unprotected" X="0" Y="96" Width="330" Height="17"
                          Text="Unprotected — plaintext in config file (development only)" />
           </RadioButtonGroup>
         </Control>
 
-        <!-- Warning label for Unprotected mode -->
-        <Control Id="WarningText" Type="Text" X="20" Y="205" Width="330" Height="26"
+        <Control Id="WarningText" Type="Text" X="20" Y="178" Width="330" Height="18"
                  NoPrefix="yes" Hidden="yes"
                  ShowCondition="JENKINS_SECRET_MODE = &quot;Unprotected&quot;"
-                 Text="WARNING: Unprotected mode stores the secret in plaintext in appsettings.json. Use only for development." />
+                 Text="WARNING: Unprotected mode stores the secret in plaintext in appsettings.json." />
+
+        <!-- DPAPI scope (only meaningful when Mode = Dpapi; harmless otherwise) -->
+        <Control Id="ScopeLabel" Type="Text" X="20" Y="200" Width="90" Height="13" NoPrefix="yes"
+                 Text="DPAPI scope:" />
+        <Control Id="ScopeGroup" Type="RadioButtonGroup" X="112" Y="198" Width="240" Height="16"
+                 Property="JENKINS_DPAPI_SCOPE">
+          <RadioButtonGroup Property="JENKINS_DPAPI_SCOPE">
+            <RadioButton Value="Machine" X="0" Y="0" Width="80" Height="16" Text="Machine" />
+            <RadioButton Value="User" X="84" Y="0" Width="150" Height="16" Text="User (service acct)" />
+          </RadioButtonGroup>
+        </Control>
+
+        <!-- Pass secret to the agent via an ACL-restricted file instead of the command line -->
+        <Control Id="ViaFileCheck" Type="CheckBox" X="20" Y="217" Width="330" Height="16"
+                 Property="JENKINS_VIA_FILE" CheckBoxValue="1"
+                 Text="Pass secret to agent via file (keeps it off the process table)" />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 

--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -134,7 +134,7 @@
           <Publish Event="NewDialog" Value="JenkinsConfigDlg" />
         </Control>
         <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="&amp;Next">
-          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+          <Publish Event="NewDialog" Value="AdvancedOptionsDlg" />
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="Cancel">
           <Publish Event="SpawnDialog" Value="CancelDlg" />
@@ -152,10 +152,72 @@
         </Control>
       </Dialog>
 
+      <!-- ════════════════════════════════════════════════════════════════════
+           Page 3: Advanced Options
+           ════════════════════════════════════════════════════════════════════ -->
+      <Dialog Id="AdvancedOptionsDlg" Width="370" Height="270" Title="[ProductName] Setup">
+
+        <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15"
+                 Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Advanced Options" />
+        <Control Id="Description" Type="Text" X="25" Y="23" Width="300" Height="15"
+                 Transparent="yes" NoPrefix="yes"
+                 Text="Optional runtime, logging and recovery settings. Defaults are fine for most installs." />
+        <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
+                 TabSkip="no" Text="WixUI_Bmp_Banner" />
+        <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+
+        <!-- Data directory -->
+        <Control Id="DataLabel" Type="Text" X="15" Y="60" Width="130" Height="13" NoPrefix="yes"
+                 Text="Data Directory (opt):" />
+        <Control Id="DataEdit" Type="Edit" X="150" Y="58" Width="205" Height="16" Property="DATAFOLDER" />
+
+        <!-- Custom java args -->
+        <Control Id="ArgsLabel" Type="Text" X="15" Y="84" Width="130" Height="13" NoPrefix="yes"
+                 Text="Custom Java Args (opt):" />
+        <Control Id="ArgsEdit" Type="Edit" X="150" Y="82" Width="205" Height="16" Property="JENKINS_CUSTOM_ARGS" />
+
+        <!-- Allowed env vars -->
+        <Control Id="EnvLabel" Type="Text" X="15" Y="108" Width="130" Height="13" NoPrefix="yes"
+                 Text="Allowed Env Vars (opt):" />
+        <Control Id="EnvEdit" Type="Edit" X="150" Y="106" Width="205" Height="16" Property="JENKINS_ALLOWED_ENV" />
+
+        <!-- Checkboxes -->
+        <Control Id="SanitizeCheck" Type="CheckBox" X="15" Y="132" Width="340" Height="16"
+                 Property="JENKINS_SANITIZE_ENV" CheckBoxValue="1"
+                 Text="Sanitize the agent child environment (recommended)" />
+        <Control Id="DebugCheck" Type="CheckBox" X="15" Y="152" Width="340" Height="16"
+                 Property="JENKINS_DEBUG" CheckBoxValue="1"
+                 Text="Enable verbose (debug) Java agent logging" />
+        <Control Id="CompactCheck" Type="CheckBox" X="15" Y="172" Width="340" Height="16"
+                 Property="JENKINS_COMPACT_LOG" CheckBoxValue="1"
+                 Text="Use compact JSON log format" />
+
+        <!-- Numeric fields on one row -->
+        <Control Id="RetainLabel" Type="Text" X="15" Y="198" Width="120" Height="13" NoPrefix="yes"
+                 Text="Retained log files:" />
+        <Control Id="RetainEdit" Type="Edit" X="138" Y="196" Width="40" Height="16" Property="JENKINS_RETAINED_LOGS" />
+        <Control Id="RetryLabel" Type="Text" X="195" Y="198" Width="120" Height="13" NoPrefix="yes"
+                 Text="Max retries (0=inf):" />
+        <Control Id="RetryEdit" Type="Edit" X="315" Y="196" Width="40" Height="16" Property="JENKINS_MAX_RETRIES" />
+
+        <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="&amp;Back">
+          <Publish Event="NewDialog" Value="SecurityOptionsDlg" />
+        </Control>
+        <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="&amp;Next">
+          <Publish Event="NewDialog" Value="VerifyReadyDlg" />
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="Cancel">
+          <Publish Event="SpawnDialog" Value="CancelDlg" />
+        </Control>
+
+      </Dialog>
+
       <!-- ─── Wire into WixUI_InstallDir sequence ─── -->
       <!-- Default: License → InstallDirDlg (no override needed, WixUI_InstallDir handles it) -->
       <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="JenkinsConfigDlg" Order="2" />
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SecurityOptionsDlg" Order="2" />
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="AdvancedOptionsDlg" Order="2" />
 
     </UI>
   </Fragment>

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -81,14 +81,35 @@
                   ExeCommand='update-secret --silent --set-data-dir "[DATAFOLDER]"'
                   Execute="deferred" Impersonate="no" />
 
-    <!-- Both CAs must run AFTER InstallFiles (the exe must be on disk to invoke) and BEFORE StartServices:
+    <!-- Advanced optional fields, applied via the update-secret merge flag. Split across three CAs purely to
+         keep each authored command under the MSI 255-char Target limit. Possibly-empty values are quoted
+         so an empty property does not swallow the following flag. -->
+    <CustomAction Id="WriteAdvanced1"
+                  FileRef="JenkinsAsService.exe"
+                  ExeCommand='update-secret --silent --merge --method [JENKINS_METHOD] --dpapi-scope [JENKINS_DPAPI_SCOPE] --via-file "[JENKINS_VIA_FILE]" --max-retries [JENKINS_MAX_RETRIES]'
+                  Execute="deferred" Impersonate="no" />
+    <CustomAction Id="WriteAdvanced2"
+                  FileRef="JenkinsAsService.exe"
+                  ExeCommand='update-secret --silent --merge --debug "[JENKINS_DEBUG]" --compact-log "[JENKINS_COMPACT_LOG]" --retained-logs [JENKINS_RETAINED_LOGS] --sanitize-env "[JENKINS_SANITIZE_ENV]"'
+                  Execute="deferred" Impersonate="no" />
+    <CustomAction Id="WriteAdvanced3"
+                  FileRef="JenkinsAsService.exe"
+                  ExeCommand='update-secret --silent --merge --custom-args "[JENKINS_CUSTOM_ARGS]" --allowed-env "[JENKINS_ALLOWED_ENV]"'
+                  Execute="deferred" Impersonate="no" />
+
+    <!-- All five CAs must run AFTER InstallFiles (the exe must be on disk to invoke) and BEFORE StartServices:
          the service is registered with Start="install" (ServiceControl, Wait="yes"), so SCM launches it at
          the standard StartServices action. If appsettings.json / the data dir aren't written yet, the service
          fails its pre-flight config validation, StartServices reports failure, and the install rolls back.
-         Writing config before StartServices is the fix — do not move these back to Before=InstallFinalize. -->
+         Writing config before StartServices is the fix — do not move these back to Before=InstallFinalize.
+         WriteAdvanced1/2/3 apply the optional fields via the update-secret merge flag between WriteConfig
+         (required fields) and SetDataDir (data directory), preserving that ordering guarantee. -->
     <InstallExecuteSequence>
       <Custom Action="WriteConfig" After="InstallFiles" Condition="NOT Installed" />
-      <Custom Action="SetDataDir" After="WriteConfig" Condition="NOT Installed" />
+      <Custom Action="WriteAdvanced1" After="WriteConfig" Condition="NOT Installed" />
+      <Custom Action="WriteAdvanced2" After="WriteAdvanced1" Condition="NOT Installed" />
+      <Custom Action="WriteAdvanced3" After="WriteAdvanced2" Condition="NOT Installed" />
+      <Custom Action="SetDataDir" After="WriteAdvanced3" Condition="NOT Installed" />
     </InstallExecuteSequence>
 
   </Package>

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -29,6 +29,19 @@
     <Property Id="JENKINS_SECRET_MODE" Value="Dpapi" Secure="yes" />
     <Property Id="JENKINS_THUMBPRINT" Secure="yes" />
 
+    <!-- Optional-field properties. Each carries its ServiceSettings default so an untouched field
+         reproduces current behaviour. Bool fields use "1" (checked) / "" (unchecked) from checkboxes. -->
+    <Property Id="JENKINS_METHOD" Value="Auto" Secure="yes" />
+    <Property Id="JENKINS_DPAPI_SCOPE" Value="Machine" Secure="yes" />
+    <Property Id="JENKINS_VIA_FILE" Value="1" Secure="yes" />
+    <Property Id="JENKINS_CUSTOM_ARGS" Secure="yes" />
+    <Property Id="JENKINS_ALLOWED_ENV" Secure="yes" />
+    <Property Id="JENKINS_SANITIZE_ENV" Value="1" Secure="yes" />
+    <Property Id="JENKINS_DEBUG" Secure="yes" />
+    <Property Id="JENKINS_COMPACT_LOG" Secure="yes" />
+    <Property Id="JENKINS_RETAINED_LOGS" Value="3" Secure="yes" />
+    <Property Id="JENKINS_MAX_RETRIES" Value="0" Secure="yes" />
+
     <!-- ─── Service identity (least privilege). Default: virtual service account 'NT SERVICE\Jenkins'.
          For a password-based or gMSA account, override all three: SERVICE_ACCOUNT='DOMAIN\svc' (+ '$'
          for gMSA), SERVICE_ACCOUNT_DOMAIN/SERVICE_ACCOUNT_NAME (for the folder ACL), and

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -68,9 +68,14 @@
                   ExeCommand='update-secret --silent --set-data-dir "[DATAFOLDER]"'
                   Execute="deferred" Impersonate="no" />
 
+    <!-- Both CAs must run AFTER InstallFiles (the exe must be on disk to invoke) and BEFORE StartServices:
+         the service is registered with Start="install" (ServiceControl, Wait="yes"), so SCM launches it at
+         the standard StartServices action. If appsettings.json / the data dir aren't written yet, the service
+         fails its pre-flight config validation, StartServices reports failure, and the install rolls back.
+         Writing config before StartServices is the fix — do not move these back to Before=InstallFinalize. -->
     <InstallExecuteSequence>
-      <Custom Action="WriteConfig" Before="SetDataDir" Condition="NOT Installed" />
-      <Custom Action="SetDataDir" Before="InstallFinalize" Condition="NOT Installed" />
+      <Custom Action="WriteConfig" After="InstallFiles" Condition="NOT Installed" />
+      <Custom Action="SetDataDir" After="WriteConfig" Condition="NOT Installed" />
     </InstallExecuteSequence>
 
   </Package>

--- a/src/JenkinsAsService/SecretWriter.cs
+++ b/src/JenkinsAsService/SecretWriter.cs
@@ -37,25 +37,7 @@ public static class SecretWriter
         var jenkins = BuildJenkinsSection(
             configSecret, mode, server, agentName, javaPath, dpapiScope, controllerCertThumbprint, existingJenkins);
 
-        var root = new JsonObject();
-        if (existingRoot != null)
-        {
-            foreach (var kvp in existingRoot)
-            {
-                if (kvp.Key != ConfigSectionName)
-                {
-                    root[kvp.Key] = kvp.Value?.DeepClone();
-                }
-            }
-        }
-
-        root[ConfigSectionName] = jenkins;
-
-        var options = new JsonSerializerOptions { WriteIndented = true };
-        // basePath is always the trusted application base directory (AppContext.BaseDirectory);
-        // no CLI option sets it and the filename is a constant, so there is no path-traversal vector.
-        // nosemgrep: csharp.lang.security.filesystem.unsafe-path-combine.unsafe-path-combine
-        File.WriteAllText(configPath, root.ToJsonString(options), Encoding.UTF8);
+        WriteRoot(configPath, existingRoot, jenkins);
 
         if (!string.IsNullOrWhiteSpace(serviceAccount))
         {
@@ -86,6 +68,61 @@ public static class SecretWriter
         }
         agent[ConfigKeys.Agent.DataDirectory] = dataDirectory;
 
+        WriteRoot(configPath, existingRoot, jenkins);
+    }
+
+    /// <summary>
+    /// Surgically merges the supplied optional fields into the <c>Jenkins</c> section of appsettings.json,
+    /// creating any missing sub-section. Every field not supplied (null) — and every other top-level
+    /// section, plus the already-written secret — is preserved verbatim. Used by the installer's advanced
+    /// custom actions. The file's existing ACL is preserved (File.WriteAllText truncates in place).
+    /// </summary>
+    public static void MergeConfig(string basePath, ConfigMergeFields fields)
+    {
+        var configPath = Path.Combine(basePath, ConfigFileName);
+        var existingRoot = ReadExistingRoot(configPath);
+        var jenkins = existingRoot?[ConfigSectionName] is JsonObject existingJenkins
+            ? (JsonObject)existingJenkins.DeepClone()
+            : new JsonObject();
+
+        if (fields.Method is { } method)
+            GetOrCreate(jenkins, ConfigKeys.Connection.Name)[ConfigKeys.Connection.Method] = method.ToString();
+        if (fields.DpapiScope is { } scope)
+            GetOrCreate(jenkins, ConfigKeys.Secret.Name)[ConfigKeys.Secret.DpapiScope] = scope.ToString();
+        if (fields.ViaFile is { } viaFile)
+            GetOrCreate(jenkins, ConfigKeys.Secret.Name)[ConfigKeys.Secret.ViaFile] = viaFile;
+        if (fields.CustomArguments is { } customArgs)
+            GetOrCreate(jenkins, ConfigKeys.Agent.Name)[ConfigKeys.Agent.CustomArguments] = customArgs;
+        if (fields.SanitizeEnvironment is { } sanitize)
+            GetOrCreate(jenkins, ConfigKeys.Hardening.Name)[ConfigKeys.Hardening.SanitizeEnvironment] = sanitize;
+        if (fields.AllowedEnvironmentVariables is { } allowed)
+            GetOrCreate(jenkins, ConfigKeys.Hardening.Name)[ConfigKeys.Hardening.AllowedEnvironmentVariables] = allowed;
+        if (fields.DebugMode is { } debug)
+            GetOrCreate(jenkins, ConfigKeys.Logging.Name)[ConfigKeys.Logging.DebugMode] = debug;
+        if (fields.CompactLog is { } compact)
+            GetOrCreate(jenkins, ConfigKeys.Logging.Name)[ConfigKeys.Logging.CompactLog] = compact;
+        if (fields.RetainedLogs is { } retained)
+            GetOrCreate(jenkins, ConfigKeys.Logging.Name)[ConfigKeys.Logging.RetainedLogs] = retained;
+        if (fields.MaxRetries is { } maxRetries)
+            GetOrCreate(jenkins, ConfigKeys.Recovery.Name)[ConfigKeys.Recovery.MaxRetries] = maxRetries;
+
+        WriteRoot(configPath, existingRoot, jenkins);
+    }
+
+    private static JsonObject GetOrCreate(JsonObject parent, string key)
+    {
+        if (parent[key] is JsonObject existing)
+        {
+            return existing;
+        }
+        var created = new JsonObject();
+        parent[key] = created;
+        return created;
+    }
+
+    // Rebuilds the root: every non-Jenkins top-level section is preserved, the Jenkins section replaced.
+    private static void WriteRoot(string configPath, JsonObject? existingRoot, JsonObject jenkins)
+    {
         var root = new JsonObject();
         if (existingRoot != null)
         {
@@ -267,4 +304,22 @@ public static class SecretWriter
 
         return CredTargetName;
     }
+}
+
+/// <summary>
+/// Optional configuration fields for <see cref="SecretWriter.MergeConfig"/>. Each member is nullable;
+/// a <c>null</c> member leaves that field unchanged in the existing appsettings.json.
+/// </summary>
+public sealed record ConfigMergeFields
+{
+    public ConnectionMethod? Method { get; init; }
+    public DpapiScope? DpapiScope { get; init; }
+    public bool? ViaFile { get; init; }
+    public string? CustomArguments { get; init; }
+    public bool? SanitizeEnvironment { get; init; }
+    public string? AllowedEnvironmentVariables { get; init; }
+    public bool? DebugMode { get; init; }
+    public bool? CompactLog { get; init; }
+    public int? RetainedLogs { get; init; }
+    public int? MaxRetries { get; init; }
 }

--- a/src/JenkinsAsService/UpdateSecretCommand.cs
+++ b/src/JenkinsAsService/UpdateSecretCommand.cs
@@ -33,6 +33,17 @@ public static class UpdateSecretCommand
                                   Silent: requires --username; password from env JAS_IMPERSONATE_PASSWORD.
           --username <value>      Windows account for impersonation (DOMAIN\account)
           --silent                Non-interactive; requires --secret/--secret-file/--secret-env, --url, --mode
+          --merge                 Merge only the optional fields below into an existing appsettings.json
+                                  (no secret written). Used by the installer's advanced custom actions.
+          --method <value>        Connection transport: Auto, WebSocket, Https
+          --via-file <bool>       Pass secret to agent via file (true/false)
+          --custom-args <value>   Extra java.exe arguments
+          --sanitize-env <bool>   Sanitize the agent child environment (true/false)
+          --allowed-env <value>   Extra env var names to pass through (semicolon/comma separated)
+          --debug <bool>          Verbose Java agent logging (true/false)
+          --compact-log <bool>    Compact JSON log format (true/false)
+          --retained-logs <int>   Number of rolled log files to keep
+          --max-retries <int>     Max auto-recovery attempts (0 = infinite)
           --help                  Show this help
         """;
 
@@ -67,6 +78,16 @@ public static class UpdateSecretCommand
         public string? Username;
         public bool Silent;
         public bool Impersonate;
+        public bool Merge;
+        public ConnectionMethod? Method;
+        public bool? ViaFile;
+        public string? CustomArgs;
+        public bool? SanitizeEnv;
+        public string? AllowedEnv;
+        public bool? DebugMode;
+        public bool? CompactLog;
+        public int? RetainedLogs;
+        public int? MaxRetries;
     }
 
     public static int Run(string[] args)
@@ -96,6 +117,26 @@ public static class UpdateSecretCommand
         {
             SecretWriter.SetDataDirectory(basePath, parsed.SetDataDir);
             Console.WriteLine($"Data directory set to {parsed.SetDataDir}");
+            return 0;
+        }
+
+        // Installer-only path: surgically merge optional fields into an already-written config, then exit.
+        if (parsed.Merge)
+        {
+            SecretWriter.MergeConfig(basePath, new ConfigMergeFields
+            {
+                Method = parsed.Method,
+                DpapiScope = parsed.DpapiScope,
+                ViaFile = parsed.ViaFile,
+                CustomArguments = parsed.CustomArgs,
+                SanitizeEnvironment = parsed.SanitizeEnv,
+                AllowedEnvironmentVariables = parsed.AllowedEnv,
+                DebugMode = parsed.DebugMode,
+                CompactLog = parsed.CompactLog,
+                RetainedLogs = parsed.RetainedLogs,
+                MaxRetries = parsed.MaxRetries
+            });
+            Console.WriteLine("Optional configuration merged into appsettings.json.");
             return 0;
         }
 
@@ -162,6 +203,33 @@ public static class UpdateSecretCommand
             case "--username":
                 state.Username = Next(args, ref i);
                 return true;
+            case "--method":
+                state.Method = ParseMethod(Next(args, ref i));
+                return true;
+            case "--via-file":
+                state.ViaFile = ParseBool(Next(args, ref i));
+                return true;
+            case "--custom-args":
+                state.CustomArgs = Next(args, ref i);
+                return true;
+            case "--sanitize-env":
+                state.SanitizeEnv = ParseBool(Next(args, ref i));
+                return true;
+            case "--allowed-env":
+                state.AllowedEnv = Next(args, ref i);
+                return true;
+            case "--debug":
+                state.DebugMode = ParseBool(Next(args, ref i));
+                return true;
+            case "--compact-log":
+                state.CompactLog = ParseBool(Next(args, ref i));
+                return true;
+            case "--retained-logs":
+                state.RetainedLogs = ParseInt(Next(args, ref i));
+                return true;
+            case "--max-retries":
+                state.MaxRetries = ParseInt(Next(args, ref i));
+                return true;
             default:
                 return false;
         }
@@ -176,6 +244,9 @@ public static class UpdateSecretCommand
                 return true;
             case "--impersonate":
                 state.Impersonate = true;
+                return true;
+            case "--merge":
+                state.Merge = true;
                 return true;
             default:
                 return false;
@@ -563,6 +634,37 @@ public static class UpdateSecretCommand
         Console.Error.WriteLine($"Error: unknown dpapi-scope '{value}'. Valid: Machine, User");
         return null;
     }
+
+    // Returns null on invalid input so a typo fails rather than silently defaulting.
+    internal static ConnectionMethod? ParseMethod(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        if (Enum.TryParse<ConnectionMethod>(value, ignoreCase: true, out var method))
+        {
+            return method;
+        }
+
+        Console.Error.WriteLine($"Error: unknown method '{value}'. Valid: Auto, WebSocket, Https");
+        return null;
+    }
+
+    // Maps checkbox-style values to bool. An empty string (unchecked MSI checkbox) is false.
+    // Unrecognised values return null so the caller leaves the field unchanged.
+    internal static bool? ParseBool(string? value) =>
+        value?.Trim().ToLowerInvariant() switch
+        {
+            "1" or "true" or "yes" or "on" => true,
+            "0" or "false" or "no" or "off" or "" => false,
+            null => null,
+            _ => null
+        };
+
+    internal static int? ParseInt(string? value) =>
+        int.TryParse(value, out var n) ? n : null;
 
     private static string ReadMaskedInput()
     {

--- a/tests/JenkinsAsService.Tests/ConfigBindingTests.cs
+++ b/tests/JenkinsAsService.Tests/ConfigBindingTests.cs
@@ -118,4 +118,52 @@ public class ConfigBindingTests
 
         return null;
     }
+
+    [Fact]
+    public void Generated_full_config_binds_to_ServiceSettings_with_all_enums()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "JAS_Bind_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Simulate the installer: WriteConfig then the merge CAs.
+            SecretWriter.WriteConfig(tempDir, "secret", SecretMode.Dpapi, "https://jenkins:8443", "agent-x", @"C:\jdk");
+            SecretWriter.MergeConfig(tempDir, new ConfigMergeFields
+            {
+                Method = ConnectionMethod.WebSocket,
+                DpapiScope = DpapiScope.User,
+                ViaFile = false,
+                CustomArguments = "-noCertificateCheck",
+                SanitizeEnvironment = false,
+                AllowedEnvironmentVariables = "MAVEN_OPTS",
+                DebugMode = true,
+                CompactLog = true,
+                RetainedLogs = 9,
+                MaxRetries = 6
+            });
+
+            var config = new ConfigurationBuilder()
+                .SetBasePath(tempDir)
+                .AddJsonFile("appsettings.json")
+                .Build();
+            var settings = config.GetSection("Jenkins").Get<ServiceSettings>()!;
+
+            settings.Connection.Method.Should().Be(ConnectionMethod.WebSocket);
+            settings.Connection.AgentName.Should().Be("agent-x");
+            settings.Secret.Mode.Should().Be(SecretMode.Dpapi);
+            settings.Secret.DpapiScope.Should().Be(DpapiScope.User);
+            settings.Secret.ViaFile.Should().BeFalse();
+            settings.Agent.CustomArguments.Should().Be("-noCertificateCheck");
+            settings.Hardening.SanitizeEnvironment.Should().BeFalse();
+            settings.Hardening.AllowedEnvironmentVariables.Should().Be("MAVEN_OPTS");
+            settings.Logging.DebugMode.Should().BeTrue();
+            settings.Logging.CompactLog.Should().BeTrue();
+            settings.Logging.RetainedLogs.Should().Be(9);
+            settings.Recovery.MaxRetries.Should().Be(6);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
 }

--- a/tests/JenkinsAsService.Tests/SecretWriterMergeTests.cs
+++ b/tests/JenkinsAsService.Tests/SecretWriterMergeTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2024 All rights reserved
+using System.Text.Json;
+using FluentAssertions;
+
+namespace JenkinsAsService.Tests;
+
+public class SecretWriterMergeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SecretWriterMergeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "JAS_Merge_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private JsonElement Jenkins() =>
+        JsonDocument.Parse(File.ReadAllText(Path.Combine(_tempDir, "appsettings.json")))
+            .RootElement.GetProperty("Jenkins");
+
+    [Fact]
+    public void Merge_sets_all_provided_fields_in_correct_subsections()
+    {
+        SecretWriter.MergeConfig(_tempDir, new ConfigMergeFields
+        {
+            Method = ConnectionMethod.WebSocket,
+            DpapiScope = DpapiScope.User,
+            ViaFile = false,
+            CustomArguments = "-noCertificateCheck",
+            SanitizeEnvironment = false,
+            AllowedEnvironmentVariables = "MAVEN_OPTS;GRADLE_USER_HOME",
+            DebugMode = true,
+            CompactLog = true,
+            RetainedLogs = 7,
+            MaxRetries = 5
+        });
+
+        var j = Jenkins();
+        j.GetProperty("Connection").GetProperty("Method").GetString().Should().Be("WebSocket");
+        j.GetProperty("Secret").GetProperty("DpapiScope").GetString().Should().Be("User");
+        j.GetProperty("Secret").GetProperty("ViaFile").GetBoolean().Should().BeFalse();
+        j.GetProperty("Agent").GetProperty("CustomArguments").GetString().Should().Be("-noCertificateCheck");
+        j.GetProperty("Hardening").GetProperty("SanitizeEnvironment").GetBoolean().Should().BeFalse();
+        j.GetProperty("Hardening").GetProperty("AllowedEnvironmentVariables").GetString().Should().Be("MAVEN_OPTS;GRADLE_USER_HOME");
+        j.GetProperty("Logging").GetProperty("DebugMode").GetBoolean().Should().BeTrue();
+        j.GetProperty("Logging").GetProperty("CompactLog").GetBoolean().Should().BeTrue();
+        j.GetProperty("Logging").GetProperty("RetainedLogs").GetInt32().Should().Be(7);
+        j.GetProperty("Recovery").GetProperty("MaxRetries").GetInt32().Should().Be(5);
+    }
+
+    [Fact]
+    public void Merge_preserves_secret_and_unset_fields()
+    {
+        const string existingJson =
+            "{\"Jenkins\":{" +
+            "\"Connection\":{\"Url\":\"https://j:8443\",\"Method\":\"Auto\"}," +
+            "\"Secret\":{\"Value\":\"keep-me\",\"Mode\":\"Dpapi\"}," +
+            "\"Agent\":{\"JavaPath\":\"C:\\\\jdk\"}}," +
+            "\"Telemetry\":{\"Enabled\":true}}";
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"), existingJson);
+
+        // Only change one field.
+        SecretWriter.MergeConfig(_tempDir, new ConfigMergeFields { MaxRetries = 3 });
+
+        var root = JsonDocument.Parse(File.ReadAllText(Path.Combine(_tempDir, "appsettings.json"))).RootElement;
+        var j = root.GetProperty("Jenkins");
+        j.GetProperty("Recovery").GetProperty("MaxRetries").GetInt32().Should().Be(3);
+        j.GetProperty("Secret").GetProperty("Value").GetString().Should().Be("keep-me", "the secret must be untouched");
+        j.GetProperty("Secret").GetProperty("Mode").GetString().Should().Be("Dpapi");
+        j.GetProperty("Connection").GetProperty("Url").GetString().Should().Be("https://j:8443");
+        j.GetProperty("Agent").GetProperty("JavaPath").GetString().Should().Be(@"C:\jdk");
+        root.GetProperty("Telemetry").GetProperty("Enabled").GetBoolean().Should().BeTrue("other sections survive");
+    }
+
+    [Fact]
+    public void Merge_on_missing_file_creates_valid_section()
+    {
+        SecretWriter.MergeConfig(_tempDir, new ConfigMergeFields { Method = ConnectionMethod.Https });
+
+        Jenkins().GetProperty("Connection").GetProperty("Method").GetString().Should().Be("Https");
+    }
+
+    [Fact]
+    public void Merge_with_all_null_fields_is_a_noop_write()
+    {
+        const string existingJson = "{\"Jenkins\":{\"Secret\":{\"Value\":\"s\"}}}";
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"), existingJson);
+
+        SecretWriter.MergeConfig(_tempDir, new ConfigMergeFields());
+
+        Jenkins().GetProperty("Secret").GetProperty("Value").GetString().Should().Be("s");
+    }
+}

--- a/tests/JenkinsAsService.Tests/UpdateSecretCommandTests.cs
+++ b/tests/JenkinsAsService.Tests/UpdateSecretCommandTests.cs
@@ -206,6 +206,84 @@ public class UpdateSecretCommandTests : IDisposable
         code.Should().Be(1);
     }
 
+    // ─── Merge mode ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Merge_applies_optional_fields_without_a_secret()
+    {
+        // Seed a config as WriteConfig would have.
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"),
+            "{\"Jenkins\":{\"Secret\":{\"Value\":\"pre-written\",\"Mode\":\"Dpapi\"}}}");
+
+        var code = UpdateSecretCommand.Run(
+            ["update-secret", "--silent", "--merge",
+             "--method", "WebSocket",
+             "--max-retries", "4",
+             "--debug", "1",
+             "--via-file", "0",
+             "--custom-args", "-noCertificateCheck"],
+            _tempDir);
+
+        code.Should().Be(0);
+        var j = ReadConfig().RootElement.GetProperty("Jenkins");
+        j.GetProperty("Connection").GetProperty("Method").GetString().Should().Be("WebSocket");
+        j.GetProperty("Recovery").GetProperty("MaxRetries").GetInt32().Should().Be(4);
+        j.GetProperty("Logging").GetProperty("DebugMode").GetBoolean().Should().BeTrue();
+        j.GetProperty("Secret").GetProperty("ViaFile").GetBoolean().Should().BeFalse();
+        j.GetProperty("Agent").GetProperty("CustomArguments").GetString().Should().Be("-noCertificateCheck");
+        j.GetProperty("Secret").GetProperty("Value").GetString().Should().Be("pre-written", "merge never touches the secret");
+    }
+
+    [Fact]
+    public void Merge_with_empty_quoted_bool_treats_as_false()
+    {
+        // Mirrors an unchecked MSI checkbox: --debug "" arrives as an empty argument.
+        File.WriteAllText(Path.Combine(_tempDir, "appsettings.json"), "{\"Jenkins\":{}}");
+
+        var code = UpdateSecretCommand.Run(
+            ["update-secret", "--silent", "--merge", "--debug", "", "--sanitize-env", "1"],
+            _tempDir);
+
+        code.Should().Be(0);
+        var logging = ReadConfig().RootElement.GetProperty("Jenkins").GetProperty("Logging");
+        logging.GetProperty("DebugMode").GetBoolean().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Auto", ConnectionMethod.Auto)]
+    [InlineData("websocket", ConnectionMethod.WebSocket)]
+    [InlineData("Https", ConnectionMethod.Https)]
+    public void ParseMethod_recognises_valid_methods(string input, ConnectionMethod expected)
+    {
+        UpdateSecretCommand.ParseMethod(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseMethod_returns_null_for_invalid()
+    {
+        UpdateSecretCommand.ParseMethod("Carrier-Pigeon").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("YES", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    public void ParseBool_maps_known_values(string input, bool expected)
+    {
+        UpdateSecretCommand.ParseBool(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseInt_parses_and_rejects()
+    {
+        UpdateSecretCommand.ParseInt("7").Should().Be(7);
+        UpdateSecretCommand.ParseInt("nope").Should().BeNull();
+        UpdateSecretCommand.ParseInt("").Should().BeNull();
+    }
+
     // ─── Helpers ──────────────────────────────────────────────────────────────
 
     private JsonDocument ReadConfig()


### PR DESCRIPTION
## Summary

Extends the MSI so every `ServiceSettings` field can be set at install time, not just the required ones.

- **`update-secret --merge` CLI mode** (`SecretWriter.MergeConfig`): surgically merges optional fields into an existing `appsettings.json` without touching the secret or required fields.
- **Installer UI:** connection method + controller-cert thumbprint fields with required-field validation; DPAPI scope and secret-via-file options on the Security page; a new **Advanced Options** wizard page for the remaining settings (custom args, env allow-list, sanitize toggle, logging, max retries).
- **Plumbing:** three deferred `WriteAdvanced1/2/3` merge custom actions (split to stay under the MSI 255-char CA limit), sequenced after `WriteConfig` and **before `StartServices`** — fixes an install rollback where the service started before its config existed.
- **Tests:** end-to-end binding test simulating the installer sequence (`WriteConfig` + `MergeConfig` → `IConfiguration` → `ServiceSettings`), covering all enums and optional fields. Suite green.
- **Docs:** Advanced Options page documented.

9 files changed, +581/−54. Branch rebased onto `main` after #48/#49 squash-merges (pure replay, identical tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)