### PR TITLE
fix(installer): link the config UI fragment so the MSI wizard actually collects settings

### DIFF
--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -6,7 +6,11 @@
     <!-- ════════════════════════════════════════════════════════════════════
          Page 1: Jenkins Configuration
          ════════════════════════════════════════════════════════════════════ -->
-    <UI>
+    <!-- The UI carries an Id so Package.wxs can pull this fragment in with a UIRef. Without that reference
+         the WiX linker drops the whole fragment as unused, the MSI ships with only the stock
+         WixUI_InstallDir pages, and the install skips straight to VerifyReadyDlg with every JENKINS_*
+         property empty (WriteConfig then fails with an empty URL and secret, installer error 1722). -->
+    <UI Id="JenkinsConfigUI">
       <Dialog Id="JenkinsConfigDlg" Width="370" Height="270" Title="[ProductName] Setup">
 
         <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15"
@@ -216,8 +220,17 @@
 
       <!-- ─── Wire into WixUI_InstallDir sequence ─── -->
       <!-- Default: License → InstallDirDlg (no override needed, WixUI_InstallDir handles it) -->
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="JenkinsConfigDlg" Order="2" />
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="AdvancedOptionsDlg" Order="2" />
+      <!-- WixUI_InstallDir already publishes InstallDirDlg/Next NewDialog to VerifyReadyDlg at Order 4
+           (gated on a validated path). This insert must use a HIGHER Order so it wins and routes into the
+           config pages; the same path-valid condition is kept so an invalid folder still re-prompts rather
+           than skipping ahead. The previous Order 2 lost to the stock Order 4 publish, so every config page
+           was skipped and WriteConfig ran with an empty URL and secret (installer error 1722). -->
+      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="JenkinsConfigDlg" Order="5"
+               Condition="WIXUI_INSTALLDIR_VALID = &quot;1&quot;" />
+      <!-- Return from the confirm page to the last config page on a fresh install; leave stock maintenance
+           navigation (Order 2) untouched when the product is already Installed. -->
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="AdvancedOptionsDlg" Order="5"
+               Condition="NOT Installed" />
 
     </UI>
   </Fragment>

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -58,6 +58,9 @@
     </Feature>
 
     <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <!-- Pull in the custom Jenkins configuration pages (ConfigDialog.wxs). This reference is what keeps the
+         linker from discarding that fragment; without it the config wizard pages never ship. -->
+    <UIRef Id="JenkinsConfigUI" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.ProjectDir)License.rtf" />
 
     <!-- ─── Custom Action: call installed exe to write appsettings.json ───


### PR DESCRIPTION
## The bug

Installing the `1.7` MSI fails with **error 1722** ("a program run as part of the setup did not finish as expected"), after the wizard skips straight to *Ready to install* without ever asking for the Jenkins URL/secret.

Verbose MSI log:
```
CustomActionSchedule(Action=WriteConfig, ... Target=update-secret --silent --secret "" --url "" --mode Dpapi ...)
CustomAction WriteConfig returned actual error code 1
Error 1722. ... Action WriteConfig
```

## Root cause

The `WriteConfig` custom action itself is fine — it correctly rejects an empty URL/secret. The real defect is in the WiX UI authoring, and it takes two forms (neither catchable by the xUnit suite, which can't exercise MSI UI sequencing):

1. **The custom config-page fragment was never linked.** `ConfigDialog.wxs` defined the pages in an anonymous `<UI>` inside an unreferenced `<Fragment>`; nothing in `Package.wxs` referenced it, so the linker discarded the whole thing. Confirmed by inspecting the compiled `1.7` MSI — its `Dialog` table held **only** stock `WixUI_InstallDir` dialogs. The install therefore never collected any `JENKINS_*` value, and `WriteConfig` ran with empty required fields.
2. **The dialog-insert Order was too low** (latent). `InstallDirDlg`/Next → `JenkinsConfigDlg` was `Order="2"`, but stock WixUI_InstallDir publishes Next → `VerifyReadyDlg` at `Order="4"`. Higher Order wins, so even once linked the pages would still be skipped.

## Fix

- `ConfigDialog.wxs`: `<UI Id="JenkinsConfigUI">`.
- `Package.wxs`: `<UIRef Id="JenkinsConfigUI" />` so the fragment is linked.
- Insert `InstallDirDlg`/Next → `JenkinsConfigDlg` at `Order="5"` with the path-valid condition; `VerifyReadyDlg`/Back → `AdvancedOptionsDlg` at `Order="5"` gated on `NOT Installed`.

## Verification

Rebuilt the MSI (0 warnings) and queried its tables directly:
- All four custom dialogs (`JenkinsConfigDlg`, `SecurityOptionsDlg`, `AdvancedOptionsDlg`, `RequiredFieldDlg`) now ship.
- Forward chain connected: `InstallDirDlg → JenkinsConfigDlg → SecurityOptionsDlg → AdvancedOptionsDlg → VerifyReadyDlg`, with the Order-5 transition beating stock Order-4.
- `JenkinsConfigDlg`/Next is gated on `JENKINS_URL AND JENKINS_SECRET`, so the wizard can't advance — and `WriteConfig` can't run — with empty required fields.

Static verification only (no live MSI install in this environment); a real install on a box is the remaining manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)