### PR TITLE
fix(installer): usable secret field + clearer config page (required markers, Java auto-detect)

### DIFF
--- a/src/JenkinsAsService.Installer/ConfigDialog.wxs
+++ b/src/JenkinsAsService.Installer/ConfigDialog.wxs
@@ -18,21 +18,23 @@
 
         <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15"
                  Transparent="yes" NoPrefix="yes"
-                 Text="Enter the Jenkins controller connection details." />
+                 Text="Enter the Jenkins controller connection details.  Fields marked * are required." />
 
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44"
                  TabSkip="no" Text="WixUI_Bmp_Banner" />
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
 
         <!-- Row 1: Jenkins URL (required) -->
-        <Control Id="UrlLabel" Type="Text" X="15" Y="62" Width="115" Height="13" NoPrefix="yes"
-                 Text="Jenkins URL (with port):" />
+        <Control Id="UrlLabel" Type="Text" X="15" Y="62" Width="120" Height="13" NoPrefix="yes"
+                 Text="* Jenkins URL (with port):" />
         <Control Id="UrlEdit" Type="Edit" X="135" Y="60" Width="220" Height="16" Property="JENKINS_URL" />
 
         <!-- Row 2: Agent Secret (required) -->
-        <Control Id="SecretLabel" Type="Text" X="15" Y="90" Width="115" Height="13" NoPrefix="yes"
-                 Text="Agent Secret:" />
-        <Control Id="SecretEdit" Type="MaskedEdit" X="135" Y="88" Width="220" Height="16" Property="JENKINS_SECRET" />
+        <Control Id="SecretLabel" Type="Text" X="15" Y="90" Width="120" Height="13" NoPrefix="yes"
+                 Text="* Agent Secret:" />
+        <!-- Password="yes" masks the secret on screen. The previous MaskedEdit rendered no usable input box
+             because it had no mask template, so the secret could not be entered at all. -->
+        <Control Id="SecretEdit" Type="Edit" Password="yes" X="135" Y="88" Width="220" Height="16" Property="JENKINS_SECRET" />
 
         <!-- Row 3: Connection Method -->
         <Control Id="MethodLabel" Type="Text" X="15" Y="118" Width="115" Height="13" NoPrefix="yes"
@@ -48,18 +50,22 @@
 
         <!-- Row 4: Controller cert thumbprint -->
         <Control Id="ThumbLabel" Type="Text" X="15" Y="146" Width="115" Height="13" NoPrefix="yes"
-                 Text="Cert Thumbprint (opt):" />
+                 Text="Cert Thumbprint:" />
         <Control Id="ThumbEdit" Type="Edit" X="135" Y="144" Width="220" Height="16" Property="JENKINS_THUMBPRINT" />
 
         <!-- Row 5: Agent name -->
         <Control Id="NameLabel" Type="Text" X="15" Y="174" Width="115" Height="13" NoPrefix="yes"
-                 Text="Agent Name (opt):" />
+                 Text="Agent Name:" />
         <Control Id="NameEdit" Type="Edit" X="135" Y="172" Width="220" Height="16" Property="JENKINS_AGENT_NAME" />
 
         <!-- Row 6: Java path -->
         <Control Id="JavaLabel" Type="Text" X="15" Y="202" Width="115" Height="13" NoPrefix="yes"
-                 Text="Java Path (opt):" />
+                 Text="Java Path:" />
         <Control Id="JavaEdit" Type="Edit" X="135" Y="200" Width="220" Height="16" Property="JENKINS_JAVA_PATH" />
+        <!-- Prefilled from JAVA_HOME by a SetProperty CA (Package.wxs). The hint tells the user how it was
+             discovered and that clearing it defers to runtime auto-detection at service start. -->
+        <Control Id="JavaHint" Type="Text" X="15" Y="218" Width="345" Height="14" Transparent="yes" NoPrefix="yes"
+                 Text="Optional. Auto-filled from JAVA_HOME; clear it to auto-detect at service start, or enter a custom path." />
 
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
 

--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -51,6 +51,12 @@
     <Property Id="SERVICE_ACCOUNT_NAME" Value="Jenkins" Secure="yes" />
     <Property Id="SERVICE_PASSWORD" Secure="yes" Hidden="yes" />
 
+    <!-- Prefill the Java Path field from JAVA_HOME so the wizard shows the detected JDK and how it was found.
+         UI sequence only and gated on an empty value, so a silent install that sets no explicit java path
+         still defers to the runtime resolver instead of pinning JAVA_HOME. The user can clear or override it. -->
+    <SetProperty Id="JENKINS_JAVA_PATH" Value="[%JAVA_HOME]" After="AppSearch" Sequence="ui"
+                 Condition="NOT JENKINS_JAVA_PATH" />
+
     <Feature Id="Main" Title="Jenkins Agent Service" Level="1">
       <ComponentGroupRef Id="PublishOutput" />
       <ComponentRef Id="ServiceComponent" />


### PR DESCRIPTION
Follow-up to #51, from a real install of the wizard. Three UI issues on the **Jenkins Configuration** page:

## 1. The Agent Secret field could not be typed into
It was authored as a `MaskedEdit` with no mask template, so no usable input box rendered — the secret literally could not be entered. Switched to `Edit` with `Password="yes"` (masked input). Verified the password style bit (`0x00200000`) is set on the control in the compiled MSI.

## 2. Required vs optional made clear
- Leading `*` on the two required fields (Jenkins URL, Agent Secret) + "Fields marked * are required" in the page description.
- Dropped the `(opt)` suffix from the optional fields (Cert Thumbprint, Agent Name, Java Path).

## 3. Java Path shows what was auto-detected
A UI-only `SetProperty` prefills the field from `JAVA_HOME` (only when empty), so the wizard shows the detected JDK, with a hint that clearing it defers to runtime auto-detection at service start. Silent installs are unaffected (UI-sequence only), so they still defer to the runtime resolver. Note: the resolver (`JavaPathResolver`) currently only probes the configured path then `JAVA_HOME` — not `PATH` or default JDK install locations.

## Verification
Rebuilt the MSI (0 warnings) and confirmed against its tables:
- `SecretEdit`: `Attributes=2097155` → password bit set.
- Labels: `* Jenkins URL...`, `* Agent Secret:`, `Cert Thumbprint:`, `Agent Name:`, `Java Path:`, plus the hint.
- `SetJENKINS_JAVA_PATH` (type 51) in `InstallUISequence` at seq 51 (after AppSearch), `Target=[%JAVA_HOME]`, condition `NOT JENKINS_JAVA_PATH`.

Static verification only; a live install remains the manual check. Ship in the next tag (1.9) — 1.8 has the wizard but still the unusable secret field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)