### PR TITLE
fix(installer): data-dir path gets a stray trailing quote (D:\Jenkins")

### DIFF
--- a/src/JenkinsAsService.Installer/Package.wxs
+++ b/src/JenkinsAsService.Installer/Package.wxs
@@ -85,10 +85,14 @@
 
     <!-- Second CA: persist the data directory. Kept separate because folding the data-dir flag into the
          command above would exceed the MSI 255-char custom-action Target limit. An EXE custom action's
-         command line is formatted at schedule time (immediate sequence), so [DATAFOLDER] resolves. -->
+         command line is formatted at schedule time (immediate sequence), so [DATAFOLDER] resolves.
+         DATAFOLDER is a directory property, so it always resolves with a trailing backslash; the extra
+         backslash before the closing quote turns that into a doubled backslash, which CommandLineToArgvW
+         reads as one literal backslash plus a proper closing quote. Without it the closing quote is escaped
+         and the exe receives a stray trailing quote in the path (belt-and-braces with SanitizePathArgument). -->
     <CustomAction Id="SetDataDir"
                   FileRef="JenkinsAsService.exe"
-                  ExeCommand='update-secret --silent --set-data-dir "[DATAFOLDER]"'
+                  ExeCommand='update-secret --silent --set-data-dir "[DATAFOLDER]\"'
                   Execute="deferred" Impersonate="no" />
 
     <!-- Advanced optional fields, applied via the update-secret merge flag. Split across three CAs purely to

--- a/src/JenkinsAsService/UpdateSecretCommand.cs
+++ b/src/JenkinsAsService/UpdateSecretCommand.cs
@@ -192,13 +192,13 @@ public static class UpdateSecretCommand
                 state.ServiceAccount = Next(args, ref i);
                 return true;
             case "--set-data-dir":
-                state.SetDataDir = Next(args, ref i);
+                state.SetDataDir = SanitizePathArgument(Next(args, ref i));
                 return true;
             case "--agent-name":
                 state.AgentName = Next(args, ref i);
                 return true;
             case "--java-path":
-                state.JavaPath = Next(args, ref i);
+                state.JavaPath = SanitizePathArgument(Next(args, ref i));
                 return true;
             case "--username":
                 state.Username = Next(args, ref i);
@@ -665,6 +665,22 @@ public static class UpdateSecretCommand
 
     internal static int? ParseInt(string? value) =>
         int.TryParse(value, out var n) ? n : null;
+
+    // Recovers a filesystem path passed on an MSI custom-action command line. A WiX directory property such as
+    // DATAFOLDER resolves with a trailing backslash (e.g. "D:\Jenkins\"); once wrapped in quotes on the command
+    // line the closing \" is parsed by CommandLineToArgvW as an escaped quote, so the process actually receives
+    // 'D:\Jenkins"'. Strip that stray trailing quote and normalise a trailing separator so the stored path is
+    // clean (drive roots like "D:\" are preserved). Returns null when nothing meaningful remains.
+    internal static string? SanitizePathArgument(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var sanitized = value.Trim().TrimEnd('"').Trim();
+        return sanitized.Length == 0 ? null : Path.TrimEndingDirectorySeparator(sanitized);
+    }
 
     private static string ReadMaskedInput()
     {

--- a/tests/JenkinsAsService.Tests/UpdateSecretCommandTests.cs
+++ b/tests/JenkinsAsService.Tests/UpdateSecretCommandTests.cs
@@ -284,6 +284,44 @@ public class UpdateSecretCommandTests : IDisposable
         UpdateSecretCommand.ParseInt("").Should().BeNull();
     }
 
+    // ─── SanitizePathArgument ────────────────────────────────────────────────
+    // Guards the DATAFOLDER command-line escaping bug: a directory property resolves as "D:\Jenkins\", and
+    // the quoted "\"" on the CA command line is parsed as an escaped quote, so the exe receives 'D:\Jenkins"'.
+
+    [Theory]
+    [InlineData("D:\\Jenkins\"", "D:\\Jenkins")]  // mangled: stray trailing quote from \"-escaping
+    [InlineData("D:\\Jenkins\\", "D:\\Jenkins")]  // clean trailing separator normalised away
+    [InlineData("D:\\Jenkins", "D:\\Jenkins")]    // already clean
+    [InlineData("  D:\\My Data\"  ", "D:\\My Data")] // spaces in path + surrounding whitespace
+    [InlineData("D:\\", "D:\\")]                    // drive root preserved
+    public void SanitizePathArgument_recovers_mangled_paths(string input, string expected)
+    {
+        UpdateSecretCommand.SanitizePathArgument(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("\"")]
+    public void SanitizePathArgument_returns_null_for_empty(string? input)
+    {
+        UpdateSecretCommand.SanitizePathArgument(input).Should().BeNull();
+    }
+
+    [Fact]
+    public void SetDataDir_with_escaped_trailing_quote_writes_clean_path()
+    {
+        // Reproduces the installer bug: the mangled 'D:\Jenkins"' must be stored as 'D:\Jenkins',
+        // not 'D:\Jenkins"' (which serialised as "D:\\Jenkins"").
+        var code = UpdateSecretCommand.Run(
+            ["update-secret", "--silent", "--set-data-dir", "D:\\Jenkins\""],
+            _tempDir);
+
+        code.Should().Be(0);
+        ReadConfig().RootElement.GetProperty("Jenkins").GetProperty("Agent")
+            .GetProperty("DataDirectory").GetString().Should().Be("D:\\Jenkins");
+    }
+
     // ─── Helpers ──────────────────────────────────────────────────────────────
 
     private JsonDocument ReadConfig()


### PR DESCRIPTION
## Bug
Entering a Data Directory such as `D:\Jenkins` in the wizard wrote:
```json
"DataDirectory": "D:\Jenkins\""
```
— a literal `"` (`"`) appended to the path.

## Root cause
`DATAFOLDER` is a WiX **directory** property, so it resolves with a trailing backslash (`D:\Jenkins\`). The `SetDataDir` custom-action command line quoted it as `--set-data-dir "D:\Jenkins\"`, and `CommandLineToArgvW` reads the closing `\"` as an **escaped quote** — so the exe received `D:\Jenkins"`.

## Fix (two layers)
1. **MSI** — emit `--set-data-dir "[DATAFOLDER]\"`. The directory's own trailing backslash + this one make `\\"`, which parses as one literal backslash plus a proper closing quote.
2. **CLI (defensive)** — `SanitizePathArgument` trims a stray trailing quote and normalizes a trailing separator for `--set-data-dir` and `--java-path` (drive roots like `D:\` preserved). Recovers the value even if a path still arrives quote-mangled.

The layers compose: clean input `D:\Jenkins\` → `D:\Jenkins`; mangled `D:\Jenkins"` → `D:\Jenkins`.

## Tests
- `SanitizePathArgument` unit cases (mangled quote, trailing sep, spaces, drive root, empty→null).
- End-to-end `--set-data-dir "D:\Jenkins\""` asserts stored value is `D:\Jenkins`.
- Full suite **170 green**.
- CA Target verified in the compiled MSI: `update-secret --silent --set-data-dir "[DATAFOLDER]\"`.

Ships in the next tag (**1.12**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)