### PR TITLE
fix(watchdog): make Auto transport fallback actually fire via -noReconnect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Key invariants (each has regression tests — don't regress them):
 - **Clean shutdown ≠ crash:** `StopAsync` sets `_stopping` before killing, so the kill-induced exit isn't counted/recovered; it also deletes the on-disk secret file.
 - **Shutdown gate reaps late-started agents:** the loop is `while (true)` with a single `_stopping || cancelled → KillAgent(); return` gate at the top. Bring-up can start an agent *after* `StopAsync`'s own `KillAgent` ran (it was a no-op while `_agent` was null); without the gate that agent is orphaned past service shutdown. Don't convert the loop back to `while (!ct.IsCancellationRequested)`.
 - **Never dereference the `_agent` field after a null-check** — `StopAsync` (another thread) nulls it via `KillAgent`. Snapshot `var agent = _agent` per iteration and use the local.
-- **Auto transport fallback:** in `Connection:Method = Auto`, a *fast* crash toggles WebSocket ↔ direct-TCP on the next bring-up; a run that stabilised then died stays on the same transport.
+- **Auto transport fallback:** in `Connection:Method = Auto`, a *fast* crash toggles WebSocket ↔ direct-TCP on the next bring-up; a run that stabilised then died stays on the same transport. Auto launches the agent with **`-noReconnect`** (`AgentTransport.UsesWatchdogReconnect`) so a failed handshake *exits the process* instead of the agent retrying that transport internally forever — that exit is what lets the fallback fire. Fixed `WebSocket`/`Https` omit `-noReconnect` and keep the agent's own faster internal reconnect (no alternate transport to try).
 - Timing (`_stabilityMs`/backoff) is injectable via `UseFastTimingForTests(...)`; `ComputeBackoffDelaySeconds`/`HasExceededMaxRetries` are `internal static` pure functions.
 
 ## Configuration

--- a/src/JenkinsAsService/AgentTransport.cs
+++ b/src/JenkinsAsService/AgentTransport.cs
@@ -19,6 +19,16 @@ internal static class AgentTransport
         current == ConnectionMethod.WebSocket ? ConnectionMethod.Https : ConnectionMethod.WebSocket;
 
     /// <summary>
+    /// True when the watchdog — not the Java agent — should own reconnection, so the agent is launched with
+    /// <c>-noReconnect</c> and exits on a failed handshake instead of retrying internally forever. Only
+    /// <c>Auto</c> needs this: that exit is what drives the WebSocket ↔ direct-TCP fallback
+    /// (<see cref="ShouldFallback"/>). Fixed transports keep the agent's own (faster) internal reconnect,
+    /// since there is no alternate transport to fall back to.
+    /// </summary>
+    internal static bool UsesWatchdogReconnect(ConnectionMethod configured) =>
+        configured == ConnectionMethod.Auto;
+
+    /// <summary>
     /// True only for <c>Auto</c> when a <em>real</em> agent process exited before reaching the stability
     /// window. A run that stabilised, or a pseudo-exit from a recovery skipped due to an unreachable
     /// controller (<paramref name="agentActuallyExited"/> = false), must not trigger a transport switch.

--- a/src/JenkinsAsService/JenkinsAgentWorker.cs
+++ b/src/JenkinsAsService/JenkinsAgentWorker.cs
@@ -26,6 +26,7 @@ public sealed class JenkinsAgentWorker : BackgroundService
     private const string ArgName = "-name";
     private const string ArgWorkDir = "-workDir";
     private const string ArgWebSocket = "-webSocket";
+    private const string ArgNoReconnect = "-noReconnect";
 
     // ─── Agent stdout/stderr log-level prefixes ───────────────────────────────
     private const string InfoPrefix = "INFO: ";
@@ -258,6 +259,16 @@ public sealed class JenkinsAgentWorker : BackgroundService
         if (_effectiveMethod == ConnectionMethod.WebSocket)
         {
             psi.ArgumentList.Add(ArgWebSocket);
+        }
+
+        // In Auto mode the watchdog owns reconnection. Without -noReconnect the Java agent retries a failed
+        // handshake internally forever, so the process never exits — and ApplyAutoTransportFallback (which
+        // fires only on a real exit) can never flip WebSocket ↔ direct-TCP, pinning a broken transport. With
+        // it, a fast handshake failure exits the process, is counted as a crash, and triggers the fallback.
+        // Fixed transports keep the agent's own faster internal reconnect (no alternate transport to try).
+        if (AgentTransport.UsesWatchdogReconnect(_settings.Connection.Method))
+        {
+            psi.ArgumentList.Add(ArgNoReconnect);
         }
 
         foreach (var arg in AgentArgumentParser.Parse(_settings.Agent.CustomArguments))

--- a/tests/JenkinsAsService.Tests/ConnectionMethodTests.cs
+++ b/tests/JenkinsAsService.Tests/ConnectionMethodTests.cs
@@ -36,6 +36,17 @@ public class ConnectionMethodTests
     }
 
     [Theory]
+    // Only Auto hands reconnection to the watchdog (via -noReconnect) so a fast exit can trigger fallback.
+    [InlineData(ConnectionMethod.Auto, true)]
+    // Fixed transports keep the agent's own internal reconnect — no alternate transport to fall back to.
+    [InlineData(ConnectionMethod.WebSocket, false)]
+    [InlineData(ConnectionMethod.Https, false)]
+    public void UsesWatchdogReconnect_only_for_Auto(ConnectionMethod configured, bool expected)
+    {
+        AgentTransport.UsesWatchdogReconnect(configured).Should().Be(expected);
+    }
+
+    [Theory]
     // Auto + a real fast exit (didn't stabilise) → fall back.
     [InlineData(ConnectionMethod.Auto, false, true, true)]
     // Auto but the run reached stability → keep the transport.

--- a/tests/JenkinsAsService.Tests/FakeAgentProcess.cs
+++ b/tests/JenkinsAsService.Tests/FakeAgentProcess.cs
@@ -49,6 +49,10 @@ internal sealed class FakeAgentProcessLauncher : IAgentProcessLauncher
     public ConcurrentQueue<FakeAgentProcess> Started { get; } = new();
     public int StartCount { get; private set; }
 
+    /// <summary>The <see cref="ProcessStartInfo"/> from the most recent <see cref="Start"/> call, so tests can
+    /// assert on the launched command line (e.g. that <c>-noReconnect</c> is or isn't present).</summary>
+    public ProcessStartInfo? LastStartInfo { get; private set; }
+
     /// <summary>Enqueue processes to be returned by successive <see cref="Start"/> calls.</summary>
     public void Enqueue(params FakeAgentProcess[] processes)
     {
@@ -61,6 +65,7 @@ internal sealed class FakeAgentProcessLauncher : IAgentProcessLauncher
     public IAgentProcess Start(ProcessStartInfo startInfo, Action<string> onOutputLine)
     {
         StartCount++;
+        LastStartInfo = startInfo;
         var process = _queued.TryDequeue(out var next) ? next : new FakeAgentProcess();
         Started.Enqueue(process);
         return process;

--- a/tests/JenkinsAsService.Tests/SupervisionLoopTests.cs
+++ b/tests/JenkinsAsService.Tests/SupervisionLoopTests.cs
@@ -134,11 +134,41 @@ public sealed class SupervisionLoopTests : IDisposable
         started.WasDisposed.Should().BeTrue();
     }
 
-    private JenkinsAgentWorker CreateWorker(int maxRetries)
+    [Fact]
+    public async Task Auto_mode_launches_the_agent_with_noReconnect_so_the_watchdog_owns_reconnection()
+    {
+        var worker = CreateWorker(maxRetries: 0, method: ConnectionMethod.Auto);
+        worker.UseFastTimingForTests(stabilityMs: 10_000, backoffBaseSec: 0, backoffMaxSec: 0);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() => _launcher.StartCount == 1);
+
+        _launcher.LastStartInfo!.ArgumentList.Should().Contain("-noReconnect",
+            "Auto must let the agent exit on a failed handshake so the transport fallback can fire");
+
+        await StopQuietly(worker);
+    }
+
+    [Fact]
+    public async Task Fixed_transport_keeps_the_agents_own_internal_reconnect()
+    {
+        var worker = CreateWorker(maxRetries: 0, method: ConnectionMethod.WebSocket);
+        worker.UseFastTimingForTests(stabilityMs: 10_000, backoffBaseSec: 0, backoffMaxSec: 0);
+
+        await worker.StartAsync(CancellationToken.None);
+        await WaitUntil(() => _launcher.StartCount == 1);
+
+        _launcher.LastStartInfo!.ArgumentList.Should().NotContain("-noReconnect",
+            "a pinned transport has nothing to fall back to, so the agent's faster internal reconnect stays");
+
+        await StopQuietly(worker);
+    }
+
+    private JenkinsAgentWorker CreateWorker(int maxRetries, ConnectionMethod method = ConnectionMethod.Auto)
     {
         var settings = new ServiceSettings
         {
-            Connection = new() { Url = "https://jenkins:8443", Method = ConnectionMethod.Auto },
+            Connection = new() { Url = "https://jenkins:8443", Method = method },
             Secret = new() { Value = "cipher", Mode = SecretMode.Unprotected, ViaFile = false },
             Agent = new() { JavaPath = _javaDir, DataDirectory = _dataDir },
             Hardening = new() { SanitizeEnvironment = false },


### PR DESCRIPTION
## Problem

Real-infra install (`Connection:Method=Auto`, reverse-proxied controller at `:443`) got stuck: the Java agent looped forever on `Failed to connect: Handshake error` / `Waiting Ns before retry` and **never fell back to direct-TCP**.

Root cause: the WebSocket ↔ direct-TCP fallback (`ApplyAutoTransportFallback`) only runs when the agent *process exits*. But without `-noReconnect` the Java agent retries a failed handshake **internally** forever, so the process never exits, the watchdog always sees a "live agent," and the fallback is effectively dead code. A broken transport stays pinned indefinitely.

## Fix

Launch the agent with `-noReconnect` **in Auto mode only** (`AgentTransport.UsesWatchdogReconnect`). A failed handshake now exits the process → counted as a fast crash → existing `ShouldFallback` toggles the transport on the next bring-up. The watchdog becomes the sole reconnection authority in Auto, which is exactly what fallback needs.

Fixed `WebSocket`/`Https` deliberately keep the agent's own (faster) internal reconnect — there is no alternate transport to fall back to.

## Behavioral note

In Auto mode a persistent double-transport failure now counts toward `Recovery:MaxRetries`. Default is `0` (infinite → toggles/retries forever, self-heals when the controller returns), so default installs are unaffected; only a finite `MaxRetries` would eventually hand off to SCM recovery — the documented give-up intent.

## Tests

- `AgentTransport.UsesWatchdogReconnect` pure predicate (Auto→true, WebSocket/Https→false).
- End-to-end: Auto launch **includes** `-noReconnect`; fixed WebSocket **omits** it (via a new `LastStartInfo` capture on the fake launcher).
- Full suite green: **175 passed**.

## Not covered here

Real-box verification that direct-TCP actually connects once WebSocket is exhausted — no live controller/proxy harness in this environment. This unblocks the fallback path; end-to-end transport behavior against real infra is still manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)