### PR TITLE
feat(agent): SHA-256 integrity-verify the cached jar + isolate it from the workdir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `.slnx` builds the app + tests only; the installer has `Build=false` and mus
 - **Config POCOs:** `ServiceSettings.cs` (nested: `Connection`/`Secret`/`Agent`/`Hardening`/`Logging`/`Recovery`), `TelemetrySettings.cs`, `ConfigKeys.cs` (centralized section/key name constants — **use these, don't hardcode config strings**), `ConnectionMethod.cs`, `SecretMode.cs`, `DpapiScope.cs`
 - **Secrets:** `ISecretResolver.cs`/`SecretResolver.cs`, `SecretWriter.cs`, `UpdateSecretCommand.cs` (the `update-secret` CLI), `TpmSecretProtector.cs`, `AgentSecretFile.cs` (`-secret @<file>` off-argv), `CertificateThumbprintValidator.cs`
 - **Agent process:** `AgentProcessLauncher.cs` (the `IAgentProcessLauncher`/`IAgentProcess` seam — production wraps `System.Diagnostics.Process`; fakes drive the watchdog in tests), `AgentArgumentParser.cs`, `AgentTransport.cs` (pure transport-selection: `InitialMethod`/`Toggle`/`ShouldFallback`), `JavaPathResolver.cs`, `ServiceSettingsValidator.cs`
-- **Networking:** `IJarDownloader.cs`/`HttpJarDownloader.cs` (ETag conditional GET; downloads to a temp file + atomic move so a truncated download can't sit behind a valid ETag), `IConnectivityChecker.cs`/`TcpConnectivityChecker.cs`
+- **Networking:** `IJarDownloader.cs`/`HttpJarDownloader.cs` (ETag conditional GET; downloads to a temp file + atomic move so a truncated download can't sit behind a valid ETag; records the jar's SHA-256 on download and re-verifies the cached jar on every 304 — a mismatch forces an unconditional re-download, so a tampered/corrupt cached jar is never launched. TOFU/local-integrity, not upstream authenticity — that's `Connection:ControllerCertThumbprint`), `IConnectivityChecker.cs`/`TcpConnectivityChecker.cs`
 - **Hardening:** `ProcessMitigations.cs`, `EnvironmentSanitizer.cs`, `ConfigAclHardener.cs`, `EventLogSourceInstaller.cs`, `DataPaths.cs` (binary/data split)
 - **Other:** `Properties/AssemblyInfo.cs` (explicit assembly attributes — required for Codacy; do not delete)
 
@@ -70,7 +70,7 @@ Settings live under the `Jenkins` section of `appsettings.json`, grouped into su
 
 - **`Connection:Url`** must carry an **explicit port**. A URL with no port is rejected; an explicitly-written standard `:443` (e.g. a reverse-proxied controller) is accepted. The rule checks the raw string for a textual port, not `Uri.IsDefaultPort`, and is **scheme-agnostic** — plain `http` (incl. `:80`) is *not* blocked here, only warned separately (secret sent unencrypted). Don't advertise `:80` in examples.
 - Key axes: `Connection:Method` (`Auto`/`WebSocket`/`Https` — `Https` means direct TCP inbound, not literal HTTPS), `Secret:Mode` (`Unprotected`/`Dpapi`/`Tpm`/`EnvironmentVariable`/`CredentialManager`), `Secret:ViaFile`, `Secret:DpapiScope`, `Hardening:SanitizeEnvironment`, `Agent:DataDirectory`, `Recovery:MaxRetries` (0 = infinite).
-- Runtime data (jar, logs, secret file, workdir) lives in `%ProgramData%\JenkinsAsService`, **separate** from the read-only install folder in `Program Files`.
+- Runtime data lives in `%ProgramData%\JenkinsAsService`, **separate** from the read-only install folder in `Program Files`. Within it: logs + secret file at the root, cached `agent.jar` (+ `.etag`/`.sha256`) under `agent\`, and the Jenkins `-workDir` under `work\` — the cache is isolated from workspace churn so a build step can't clobber the binary the watchdog launches. `DataPaths.ResolveAgentDirectory`/`ResolveWorkDirectory` derive the subdirs; don't put the jar back in the workdir root.
 
 ## Conventions & Invariants
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ JenkinsAsService replaces all of that with a proper Windows Service built on .NE
 - **Auto-start on boot** — runs under a least-privilege virtual service account (`NT SERVICE\Jenkins`), no interactive login required
 - **Event-driven watchdog** — detects agent death instantly (not polling), auto-recovers with exponential backoff (10s to 5min); a persistent crash-loop stops the service so Windows Service Recovery can act, while a merely-unreachable controller is retried indefinitely
 - **Secret protection** — TPM 2.0 hardware-backed key, DPAPI machine/user-scope encryption, Windows Credential Manager, environment variables, or plaintext
-- **Smart jar caching** — ETag-based conditional GET skips the download when `agent.jar` is unchanged
+- **Smart jar caching + integrity** — ETag-based conditional GET skips the download when `agent.jar` is unchanged; the jar's SHA-256 is recorded on download and re-verified on every reuse, so a tampered or corrupt cached jar is re-downloaded instead of launched
 - **HTTP resilience** — Polly-based retry, circuit breaker, and timeout on all HTTP calls
 - **Structured logging** — Serilog rolling file + Windows Event Log, with `ProcessId`/`MachineName` enrichment
 - **CLEF JSON mode** — machine-parseable compact log format for Seq, Datadog, or any log aggregator
@@ -138,7 +138,7 @@ All settings live in the `Jenkins` section of `appsettings.json`, grouped into t
 | `Secret:ViaFile` | No | `true` | Pass the secret as `-secret @<file>` (ACL-restricted) instead of inline, keeping it out of the process table |
 | `Agent:JavaPath` | No | `JAVA_HOME` | Path to JDK `bin` folder |
 | `Agent:CustomArguments` | No | *(empty)* | Extra `java.exe` args (supports quoted values and escaped quotes) |
-| `Agent:DataDirectory` | No | `%ProgramData%\JenkinsAsService` | Writable dir for runtime data (jar, logs, secret, work dir), separate from the read-only install folder |
+| `Agent:DataDirectory` | No | `%ProgramData%\JenkinsAsService` | Writable root for runtime data, separate from the read-only install folder: logs + secret at the root, cached `agent.jar` under `agent\`, Jenkins `-workDir` under `work\` |
 | `Hardening:SanitizeEnvironment` | No | `true` | Launch the agent with a deny-by-default environment (curated allow-list only) |
 | `Hardening:AllowedEnvironmentVariables` | No | *(empty)* | Extra env var names (`;`/`,`-separated) to pass through when sanitizing |
 | `Logging:DebugMode` | No | `false` | Verbose Java agent output in logs |
@@ -200,7 +200,7 @@ The watchdog is event-driven — it awaits the process exit signal, not a pollin
 
 1. Wait with exponential backoff (10s, 20s, 40s, ... capped at 300s)
 2. Test TCP connectivity — an **unreachable** controller is retried indefinitely and never counts toward `MaxRetries`
-3. Re-download `agent.jar` via conditional GET (ETag/304) and start a new agent process
+3. Refresh `agent.jar` via conditional GET (ETag/304); on a 304 the cached jar is SHA-256-verified (re-downloaded if it fails), then start a new agent process
 
 **Live agent** — awaits the exit signal or a 60s stability timer:
 
@@ -256,7 +256,7 @@ dotnet build src/JenkinsAsService.Installer -c Release `
 - TLS 1.2+ enforced by default (.NET 10), with optional controller certificate pinning (`ControllerCertThumbprint`)
 - Secrets encrypted at rest (TPM 2.0 hardware-backed key, DPAPI machine/user scope, or CredMgr), redacted from all logs, and passed to the agent off the command line via `-secret @<file>` so they never appear in the process table
 - Least-privilege virtual service account, deny-by-default environment block for the agent child, and Win32 process-mitigation policies (no remote/low-IL/non-System32 DLL loads, extension-point injection disabled)
-- Binary/data separation: read-only binaries in `Program Files`, writable runtime data (jar, logs, secret, work dir) in `ProgramData` — a malicious pipeline running under the agent can't overwrite the service `.exe`
+- Binary/data separation: read-only binaries in `Program Files`, writable runtime data in `ProgramData` — a malicious pipeline running under the agent can't overwrite the service `.exe`. Within the data folder the cached `agent.jar` (+ SHA-256) sits in `agent\`, isolated from the build `work\` dir, and is integrity-checked before each launch so a build step can't swap the binary the watchdog runs
 - Deterministic builds with locked NuGet restore and embedded PDB symbols
 - CycloneDX **SBOM** generated in CI and attached to every release (with SHA-256 checksum)
 - Unit tests run on every push and PR

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -129,7 +129,7 @@
             <td><code>Agent:DataDirectory</code></td>
             <td>No</td>
             <td><code>%ProgramData%\JenkinsAsService</code></td>
-            <td>Writable directory for runtime artifacts (<code>agent.jar</code>, logs, secret file, work dir), kept separate from the read-only install folder. Env vars are expanded. The MSI sets this to the chosen <code>DATAFOLDER</code>. See <a href="#data-dir-split">Data directory split</a>.</td>
+            <td>Writable directory root for runtime artifacts, kept separate from the read-only install folder. Holds logs + secret file at the root, the cached <code>agent.jar</code> under <code>agent\</code>, and the Jenkins <code>-workDir</code> under <code>work\</code>. Env vars are expanded. The MSI sets this to the chosen <code>DATAFOLDER</code>. See <a href="#data-dir-split">Data directory split</a>.</td>
           </tr>
           <tr>
             <td><code>Hardening:SanitizeEnvironment</code></td>
@@ -410,13 +410,14 @@
           <tr>
             <td>Data folder (<code>Agent:DataDirectory</code>)</td>
             <td><code>C:\ProgramData\JenkinsAsService</code></td>
-            <td><code>agent.jar</code> (+ ETag cache), <code>agent.log</code>/<code>.clef</code>, <code>.agent-secret</code>, agent work dir</td>
+            <td><code>agent.log</code>/<code>.clef</code> + <code>.agent-secret</code> at the root; cached <code>agent.jar</code> (+ <code>.etag</code>/<code>.sha256</code>) under <code>agent\</code>; Jenkins <code>-workDir</code> under <code>work\</code></td>
             <td>Service account granted write (set by the MSI)</td>
           </tr>
         </tbody>
       </table>
     </div>
     <p>Because the install folder is not writable by the agent identity, a malicious pipeline running inside the agent cannot overwrite the service binary and wait for a restart &mdash; a local privilege-escalation / persistence vector that a single shared folder can't close (the same identity needs write for data but must not have it for the binary). The MSI sets <code>Agent:DataDirectory</code> to the chosen <code>DATAFOLDER</code>; for portable/manual deployments the service defaults to <code>%ProgramData%\JenkinsAsService</code> and creates it on first run.</p>
+    <p>Inside the data folder the cached <code>agent.jar</code> and its integrity sidecars live in the <code>agent\</code> subfolder, kept out of the <code>work\</code> subfolder (the Jenkins <code>-workDir</code>) where builds churn &mdash; so a <code>git clean</code> or a workspace-path collision can't clobber the binary the watchdog launches. On download the jar's SHA-256 is recorded next to it; on every subsequent start, if the controller answers the ETag check with <code>304 Not Modified</code>, the cached jar is re-hashed and compared &mdash; any mismatch (tamper or corruption) forces an unconditional re-download rather than launching the altered jar. This is trust-on-first-use local-integrity checking; to also pin <em>who</em> the jar came from, set <a href="#cert-pinning"><code>Connection:ControllerCertThumbprint</code></a>.</p>
 
     <h3 id="cli-update-secret">CLI: update-secret</h3>
     <p>The <code>JenkinsAsService.exe update-secret</code> subcommand writes (or re-writes) <code>appsettings.json</code> with the secret processed for the chosen mode. Used by the MSI installer and manually.</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -285,7 +285,7 @@ dotnet build src/JenkinsAsService.Installer -c Release -p:PublishDir=../../publi
     <ul>
       <li>Installs to <code>C:\Program Files\Jenkins</code> (customizable via install directory dialog or <code>INSTALLFOLDER</code> property)</li>
       <li>Registers the <code>Jenkins</code> Windows Service under a least-privilege <strong>virtual service account</strong> (<code>NT SERVICE\Jenkins</code>, Automatic start) instead of <code>LocalSystem</code></li>
-      <li>Splits binaries from runtime data: binaries stay <strong>read-only</strong> in <code>C:\Program Files\Jenkins</code> (the agent account cannot overwrite the <code>.exe</code>), while runtime artifacts (<code>agent.jar</code>, logs, secret file, work dir) live in a separate writable data folder <code>C:\ProgramData\JenkinsAsService</code> (overridable via <code>DATAFOLDER</code>) where the service account is granted write</li>
+      <li>Splits binaries from runtime data: binaries stay <strong>read-only</strong> in <code>C:\Program Files\Jenkins</code> (the agent account cannot overwrite the <code>.exe</code>), while runtime artifacts live in a separate writable data folder <code>C:\ProgramData\JenkinsAsService</code> (overridable via <code>DATAFOLDER</code>) where the service account is granted write &mdash; logs and the secret file at the root, the cached <code>agent.jar</code> (+ SHA-256) under <code>agent\</code>, and the agent <code>-workDir</code> under <code>work\</code></li>
       <li>Locks down <code>appsettings.json</code> so only SYSTEM, Administrators and the service account can read it (the secret-bearing file is removed from <code>Users</code>)</li>
       <li>Pre-creates the Windows Event Log source (the low-privilege account cannot create it at runtime)</li>
       <li>Configures Windows-level service recovery automatically (<code>util:ServiceConfig</code> &mdash; restart on all 3 failures after 10s, reset daily)</li>
@@ -394,7 +394,7 @@ dotnet build src/JenkinsAsService.Installer -c Release -p:PublishDir=../../publi
             <td><code>DATAFOLDER</code></td>
             <td>No</td>
             <td><code>C:\ProgramData\JenkinsAsService</code></td>
-            <td>Writable data directory (<code>agent.jar</code>, logs, secret file, work dir). The service account is granted write here; persisted to <code>Agent:DataDirectory</code> in <code>appsettings.json</code></td>
+            <td>Writable data directory root (logs + secret file at the root, cached <code>agent.jar</code> under <code>agent\</code>, agent <code>-workDir</code> under <code>work\</code>). The service account is granted write here; persisted to <code>Agent:DataDirectory</code> in <code>appsettings.json</code></td>
           </tr>
           <tr>
             <td><code>JENKINS_URL</code></td>

--- a/src/JenkinsAsService/DataPaths.cs
+++ b/src/JenkinsAsService/DataPaths.cs
@@ -4,15 +4,24 @@ namespace JenkinsAsService;
 
 /// <summary>
 /// Resolves the writable <em>data</em> directory, kept separate from the read-only install directory
-/// (where the signed binary lives). Runtime artifacts the service must write — <c>agent.jar</c>, the
-/// ETag cache, log files, the secret file, and the agent work directory — live here so the install
+/// (where the signed binary lives). Runtime artifacts the service must write live here so the install
 /// folder can stay non-writable by the agent identity, closing the "agent overwrites its own .exe"
-/// privilege-escalation vector. Default: <c>%ProgramData%\JenkinsAsService</c> (the MSI grants the
-/// service account write on it); override via the <c>DataDirectory</c> setting.
+/// privilege-escalation vector. Within the data directory the cached agent binary lives in the
+/// <see cref="AgentFolderName"/> subfolder and the Jenkins <c>-workDir</c> in <see cref="WorkFolderName"/>,
+/// so build/workspace churn (git clean, workspace collisions) can never clobber <c>agent.jar</c> or its
+/// integrity metadata. Default root: <c>%ProgramData%\JenkinsAsService</c> (the MSI grants the service
+/// account write on it); override via the <c>DataDirectory</c> setting.
 /// </summary>
 internal static class DataPaths
 {
     internal const string AppFolderName = "JenkinsAsService";
+
+    /// <summary>Subfolder holding the cached <c>agent.jar</c> plus its ETag and SHA-256 sidecars — isolated
+    /// from the work directory so a build step can't tamper with or corrupt the binary the watchdog launches.</summary>
+    internal const string AgentFolderName = "agent";
+
+    /// <summary>Subfolder used as the Jenkins agent <c>-workDir</c> (remoting/, workspace/, build output).</summary>
+    internal const string WorkFolderName = "work";
 
     /// <summary>
     /// Returns the absolute data directory (creating it best-effort): the configured value if set
@@ -26,6 +35,19 @@ internal static class DataPaths
                 AppFolderName)
             : Environment.ExpandEnvironmentVariables(configured.Trim());
 
+        return EnsureDirectory(dir);
+    }
+
+    /// <summary>Returns (creating best-effort) the agent-binary cache subfolder under the data directory.</summary>
+    internal static string ResolveAgentDirectory(string dataDirectory) =>
+        EnsureDirectory(Path.Combine(dataDirectory, AgentFolderName));
+
+    /// <summary>Returns (creating best-effort) the agent work subfolder under the data directory.</summary>
+    internal static string ResolveWorkDirectory(string dataDirectory) =>
+        EnsureDirectory(Path.Combine(dataDirectory, WorkFolderName));
+
+    private static string EnsureDirectory(string dir)
+    {
         try
         {
             Directory.CreateDirectory(dir);

--- a/src/JenkinsAsService/HttpJarDownloader.cs
+++ b/src/JenkinsAsService/HttpJarDownloader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 All rights reserved
 
 using System.Net;
+using System.Security.Cryptography;
 
 namespace JenkinsAsService;
 
@@ -8,8 +9,10 @@ public sealed class HttpJarDownloader : IJarDownloader
 {
     private const string JarFilename = "agent.jar"; // intentional: decoupled from JenkinsAgentWorker
     private const string ETagFilename = "agent.jar.etag";
+    private const string HashFilename = "agent.jar.sha256";
     private const string TempSuffix = ".tmp";
     private const string JnlpJarsPath = "jnlpJars";
+    private const int ShortHashLength = 12;
     /// <summary>Named <see cref="System.Net.Http.HttpClient"/> key. Referenced by <c>Program.cs</c> when
     /// registering the client (with resilience + optional cert pinning), so both sides stay in sync.</summary>
     public const string ClientName = "JarDownloader";
@@ -27,16 +30,50 @@ public sealed class HttpJarDownloader : IJarDownloader
     {
         var jarPath = Path.Combine(destinationPath, JarFilename);
         var etagPath = Path.Combine(destinationPath, ETagFilename);
+        var hashPath = Path.Combine(destinationPath, HashFilename);
         var jarUri = BuildJarUri(jenkinsUri);
 
         _logger.LogInformation("Downloading {Jar} from {Uri}", JarFilename, jarUri);
 
+        // Freshness pass: conditional GET honoring the stored ETag. A 200 streams the new jar and records
+        // its SHA-256, so the hash always matches by construction — no further check needed.
+        if (await Fetch(jarUri, jarPath, etagPath, hashPath, conditional: true, ct) == FetchOutcome.Downloaded)
+        {
+            return;
+        }
+
+        // Server reports Not-Modified. Confirm the cached jar still matches the hash we recorded when we
+        // downloaded it — a mismatch means it was altered or corrupted since, so it must not be launched.
+        if (await LocalJarMatchesHash(jarPath, hashPath, ct))
+        {
+            _logger.LogInformation("{Jar} is up to date (ETag match) and SHA-256 verified — skipping download", JarFilename);
+            return;
+        }
+
+        // Local copy failed verification: force an unconditional re-download (no If-None-Match) so the
+        // server's authoritative jar replaces the bad one and a fresh hash is stored.
+        _logger.LogWarning("{Jar} failed SHA-256 verification (tampered or corrupt) — forcing a fresh download", JarFilename);
+        await Fetch(jarUri, jarPath, etagPath, hashPath, conditional: false, ct);
+    }
+
+    private enum FetchOutcome
+    {
+        Downloaded,
+        NotModified,
+    }
+
+    // One GET. Conditional adds If-None-Match (when a jar+etag pair exists) so an unchanged server jar
+    // returns 304; unconditional always re-fetches. A 200 streams the body atomically, then persists the
+    // ETag and the SHA-256 of what landed on disk.
+    private async Task<FetchOutcome> Fetch(
+        Uri jarUri, string jarPath, string etagPath, string hashPath, bool conditional, CancellationToken ct)
+    {
         using var client = _httpFactory.CreateClient(ClientName);
         using var request = new HttpRequestMessage(HttpMethod.Get, jarUri);
 
         // Only send If-None-Match when the jar file itself exists — an orphaned .etag with no jar
         // would cause a 304 and leave the caller with a missing agent.jar.
-        var storedEtag = File.Exists(jarPath) ? ReadStoredEtag(etagPath) : null;
+        var storedEtag = conditional && File.Exists(jarPath) ? ReadStoredEtag(etagPath) : null;
         if (storedEtag is not null)
         {
             request.Headers.TryAddWithoutValidation("If-None-Match", storedEtag);
@@ -46,16 +83,18 @@ public sealed class HttpJarDownloader : IJarDownloader
 
         if (response.StatusCode == HttpStatusCode.NotModified)
         {
-            _logger.LogInformation("{Jar} is up to date (ETag match) — skipping download", JarFilename);
-            return;
+            return FetchOutcome.NotModified;
         }
 
         response.EnsureSuccessStatusCode();
 
         var bytesWritten = await StreamToFile(response, jarPath, ct);
         SaveEtag(response, etagPath);
+        var hash = await SaveHash(jarPath, hashPath, ct);
 
-        _logger.LogInformation("{Jar} downloaded successfully ({Bytes} bytes)", JarFilename, bytesWritten);
+        _logger.LogInformation("{Jar} downloaded successfully ({Bytes} bytes, sha256 {Hash})",
+            JarFilename, bytesWritten, hash[..Math.Min(ShortHashLength, hash.Length)]);
+        return FetchOutcome.Downloaded;
     }
 
     private static Uri BuildJarUri(Uri jenkinsUri) =>
@@ -132,5 +171,50 @@ public sealed class HttpJarDownloader : IJarDownloader
 
         _logger.LogDebug("Saving ETag {ETag} for {Jar}", etag, JarFilename);
         File.WriteAllText(etagPath, etag);
+    }
+
+    // Records the SHA-256 (uppercase hex) of the freshly written jar next to it, so a later run can detect
+    // any change to the cached file. Trust-on-first-use: this attests the bytes we downloaded, not upstream
+    // authenticity — pair with Connection:ControllerCertThumbprint to also pin who we downloaded from.
+    private async Task<string> SaveHash(string jarPath, string hashPath, CancellationToken ct)
+    {
+        var hash = await ComputeSha256(jarPath, ct);
+        await File.WriteAllTextAsync(hashPath, hash, ct);
+        _logger.LogDebug("Saved SHA-256 {Hash} for {Jar}", hash, JarFilename);
+        return hash;
+    }
+
+    // True only when both the jar and its stored hash exist and the jar hashes to the stored value.
+    private static async Task<bool> LocalJarMatchesHash(string jarPath, string hashPath, CancellationToken ct)
+    {
+        if (!File.Exists(jarPath) || !File.Exists(hashPath))
+        {
+            return false;
+        }
+
+        string stored;
+        try
+        {
+            stored = (await File.ReadAllTextAsync(hashPath, ct)).Trim();
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(stored))
+        {
+            return false;
+        }
+
+        var actual = await ComputeSha256(jarPath, ct);
+        return string.Equals(stored, actual, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<string> ComputeSha256(string jarPath, CancellationToken ct)
+    {
+        await using var fs = new FileStream(jarPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var hash = await SHA256.HashDataAsync(fs, ct);
+        return Convert.ToHexString(hash);
     }
 }

--- a/src/JenkinsAsService/JenkinsAgentWorker.cs
+++ b/src/JenkinsAsService/JenkinsAgentWorker.cs
@@ -57,6 +57,8 @@ public sealed class JenkinsAgentWorker : BackgroundService
     private readonly IHostApplicationLifetime _lifetime;
     private readonly string _basePath;
     private string _dataDir = "";
+    private string _agentDir = "";
+    private string _workDir = "";
     private string _javaExe = "";
     private string _agentName = "";
     private string _resolvedSecret = "";
@@ -187,7 +189,10 @@ public sealed class JenkinsAgentWorker : BackgroundService
         _logger.LogInformation("Secret resolved via {Mode} mode", _settings.Secret.Mode);
 
         _dataDir = DataPaths.ResolveDataDirectory(_settings.Agent.DataDirectory);
-        _logger.LogInformation("Data directory: {DataDir}", _dataDir);
+        _agentDir = DataPaths.ResolveAgentDirectory(_dataDir);
+        _workDir = DataPaths.ResolveWorkDirectory(_dataDir);
+        _logger.LogInformation("Data directory: {DataDir} (agent cache: {AgentDir}, work dir: {WorkDir})",
+            _dataDir, _agentDir, _workDir);
 
         _effectiveMethod = AgentTransport.InitialMethod(_settings.Connection.Method);
         _logger.LogInformation("Connection method: {Configured} (starting transport: {Effective})",
@@ -217,7 +222,7 @@ public sealed class JenkinsAgentWorker : BackgroundService
 
     private ProcessStartInfo BuildProcessStartInfo()
     {
-        var jarPath = Path.Combine(_dataDir, JarFilename);
+        var jarPath = Path.Combine(_agentDir, JarFilename);
         var normalizedUrl = $"{_settings.Connection.Url.TrimEnd(TrailingSlash)}{UrlPathSeparator}";
 
         var psi = new ProcessStartInfo(_javaExe)
@@ -226,7 +231,7 @@ public sealed class JenkinsAgentWorker : BackgroundService
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             CreateNoWindow = true,
-            WorkingDirectory = _dataDir
+            WorkingDirectory = _workDir
         };
 
         AddAgentArguments(psi, jarPath, normalizedUrl);
@@ -254,7 +259,7 @@ public sealed class JenkinsAgentWorker : BackgroundService
         psi.ArgumentList.Add(ArgName);
         psi.ArgumentList.Add(_agentName);
         psi.ArgumentList.Add(ArgWorkDir);
-        psi.ArgumentList.Add(_dataDir);
+        psi.ArgumentList.Add(_workDir);
 
         if (_effectiveMethod == ConnectionMethod.WebSocket)
         {
@@ -471,7 +476,7 @@ public sealed class JenkinsAgentWorker : BackgroundService
 
         try
         {
-            await _jarDownloader.Download(new Uri(_settings.Connection.Url), _dataDir, ct);
+            await _jarDownloader.Download(new Uri(_settings.Connection.Url), _agentDir, ct);
             _agent = StartAgentProcess();
 
             // The first successful start is the initial launch; subsequent ones are restarts (metric).

--- a/src/JenkinsAsService/ServiceSettings.cs
+++ b/src/JenkinsAsService/ServiceSettings.cs
@@ -75,10 +75,12 @@ public sealed class AgentSettings
     public string CustomArguments { get; set; } = "";
 
     /// <summary>
-    /// Writable data directory for runtime artifacts the service produces — <c>agent.jar</c> (+ ETag
-    /// cache), log files, the secret file, and the agent work directory. Kept separate from the
-    /// read-only install folder so the binary can't be overwritten by the agent identity. Environment
-    /// variables are expanded. Empty (default) resolves to <c>%ProgramData%\JenkinsAsService</c>.
+    /// Writable data directory root for runtime artifacts the service produces — log files and the secret
+    /// file at the root, the cached <c>agent.jar</c> (+ ETag and SHA-256 sidecars) under <c>agent\</c>, and
+    /// the Jenkins <c>-workDir</c> under <c>work\</c> (so build/workspace churn can't clobber the binary).
+    /// Kept separate from the read-only install folder so the binary can't be overwritten by the agent
+    /// identity. Environment variables are expanded. Empty (default) resolves to
+    /// <c>%ProgramData%\JenkinsAsService</c>.
     /// </summary>
     public string DataDirectory { get; set; } = "";
 }

--- a/tests/JenkinsAsService.Tests/DataPathsTests.cs
+++ b/tests/JenkinsAsService.Tests/DataPathsTests.cs
@@ -52,4 +52,30 @@ public class DataPathsTests
         resolved.Should().NotContain("%");
         resolved.Should().EndWith(@"JAS_EnvTest_Marker");
     }
+
+    [Fact]
+    public void Agent_and_work_dirs_are_created_as_siblings_under_the_data_dir()
+    {
+        var dataDir = Path.Combine(Path.GetTempPath(), "JAS_Sub_" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dataDir);
+
+            var agentDir = DataPaths.ResolveAgentDirectory(dataDir);
+            var workDir = DataPaths.ResolveWorkDirectory(dataDir);
+
+            agentDir.Should().Be(Path.Combine(dataDir, DataPaths.AgentFolderName));
+            workDir.Should().Be(Path.Combine(dataDir, DataPaths.WorkFolderName));
+            Directory.Exists(agentDir).Should().BeTrue("the agent cache subfolder is created best-effort");
+            Directory.Exists(workDir).Should().BeTrue("the work subfolder is created best-effort");
+            agentDir.Should().NotBe(workDir, "the jar cache must be isolated from build/workspace churn");
+        }
+        finally
+        {
+            if (Directory.Exists(dataDir))
+            {
+                Directory.Delete(dataDir, recursive: true);
+            }
+        }
+    }
 }

--- a/tests/JenkinsAsService.Tests/HttpJarDownloaderTests.cs
+++ b/tests/JenkinsAsService.Tests/HttpJarDownloaderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ public class HttpJarDownloaderTests : IDisposable
     private const string JenkinsUrl = "https://jenkins:8443"; // NOSONAR
     private const string JarFilename = "agent.jar";
     private const string ETagFilename = "agent.jar.etag";
+    private const string HashFilename = "agent.jar.sha256";
     private const string ETagV1 = "\"v1\"";
     private const int TempDirSuffixLength = 8;
 
@@ -36,6 +38,10 @@ public class HttpJarDownloaderTests : IDisposable
 
     private string JarPath => Path.Combine(_tempDir, JarFilename);
     private string ETagPath => Path.Combine(_tempDir, ETagFilename);
+    private string HashPath => Path.Combine(_tempDir, HashFilename);
+
+    private static string Sha256Hex(string content) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
 
     private HttpJarDownloader CreateDownloader(FakeHandler handler)
     {
@@ -63,20 +69,75 @@ public class HttpJarDownloaderTests : IDisposable
         File.ReadAllText(JarPath).Should().Be("JARBYTES");
         File.Exists(ETagPath).Should().BeTrue();
         File.ReadAllText(ETagPath).Should().Be(ETagV1);
+        File.Exists(HashPath).Should().BeTrue("a 200 must record the jar's SHA-256 for later verification");
+        File.ReadAllText(HashPath).Should().Be(Sha256Hex("JARBYTES"));
     }
 
     [Fact]
-    public async Task Download_skips_write_on_304()
+    public async Task Download_skips_write_on_304_when_hash_matches()
     {
         File.WriteAllText(ETagPath, ETagV1);
         File.WriteAllText(JarPath, "OLDJAR");
+        File.WriteAllText(HashPath, Sha256Hex("OLDJAR"));
 
         var handler = new FakeHandler(_ => new HttpResponseMessage(HttpStatusCode.NotModified));
 
         await CreateDownloader(handler).Download(new Uri(JenkinsUrl), _tempDir, CancellationToken.None);
 
-        File.ReadAllText(JarPath).Should().Be("OLDJAR", "304 must not overwrite the existing jar");
+        File.ReadAllText(JarPath).Should().Be("OLDJAR", "304 with a matching hash must not overwrite the existing jar");
         File.ReadAllText(ETagPath).Should().Be(ETagV1, "304 must not change the stored etag");
+    }
+
+    [Fact]
+    public async Task Download_redownloads_on_304_when_local_hash_mismatches()
+    {
+        // Cached jar was tampered/corrupted after we recorded its hash: on-disk bytes no longer match.
+        File.WriteAllText(ETagPath, ETagV1);
+        File.WriteAllText(JarPath, "TAMPERED");
+        File.WriteAllText(HashPath, Sha256Hex("ORIGINAL"));
+
+        // Server still 304s the conditional request (its jar is unchanged); the forced re-fetch omits
+        // If-None-Match, so answer that unconditional GET with the authoritative jar.
+        var handler = new FakeHandler(req =>
+        {
+            if (req.Headers.Contains("If-None-Match"))
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotModified);
+            }
+
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("ORIGINAL"))
+            };
+            resp.Headers.ETag = new EntityTagHeaderValue(ETagV1);
+            return resp;
+        });
+
+        await CreateDownloader(handler).Download(new Uri(JenkinsUrl), _tempDir, CancellationToken.None);
+
+        File.ReadAllText(JarPath).Should().Be("ORIGINAL", "a hash mismatch must force a fresh download over the bad jar");
+        File.ReadAllText(HashPath).Should().Be(Sha256Hex("ORIGINAL"), "the re-download must refresh the stored hash");
+    }
+
+    [Fact]
+    public async Task Download_redownloads_on_304_when_hash_file_is_missing()
+    {
+        // Legacy/first-run state: a cached jar+etag with no recorded hash can't be verified, so re-fetch.
+        File.WriteAllText(ETagPath, ETagV1);
+        File.WriteAllText(JarPath, "UNVERIFIED");
+
+        var handler = new FakeHandler(req => req.Headers.Contains("If-None-Match")
+            ? new HttpResponseMessage(HttpStatusCode.NotModified)
+            : new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("VERIFIED"))
+            });
+
+        await CreateDownloader(handler).Download(new Uri(JenkinsUrl), _tempDir, CancellationToken.None);
+
+        File.ReadAllText(JarPath).Should().Be("VERIFIED", "an unverifiable cached jar must be re-downloaded");
+        File.Exists(HashPath).Should().BeTrue("the re-download records a hash for next time");
+        File.ReadAllText(HashPath).Should().Be(Sha256Hex("VERIFIED"));
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

The service downloads `agent.jar` and executes it as the service identity. Two gaps this closes:

1. **The cached jar shared a directory with the Jenkins `-workDir`** — build churn (`git clean`, workspace collisions) could clobber the binary the watchdog launches.
2. **No integrity check on the cached jar** — a tampered or corrupt jar would be launched on the next start.

## Changes

**Data-directory split** (`DataPaths`, `JenkinsAgentWorker`)
```
%ProgramData%\JenkinsAsService\
├─ agent.log/.clef, .agent-secret     (root, unchanged)
├─ agent\   agent.jar + .etag + .sha256   (cache, isolated from build churn)
└─ work\    Jenkins -workDir (remoting/, workspace/)
```
Install folder stays read-only to the agent identity — the "agent overwrites its own binary" invariant is preserved.

**Integrity verification** (`HttpJarDownloader`)
- On **200**: stream the jar + record its SHA-256 (matches by construction).
- On **304**: re-hash the cached jar and compare to the stored `.sha256`. Match → launch. **Mismatch or missing hash → forced unconditional re-download** (bypasses the ETag), so a bad jar is never run.

This is trust-on-first-use *local* integrity, complementary to `Connection:ControllerCertThumbprint` (upstream authenticity). Documented as such.

## Tests
`dotnet test -c Release` → **178 passed**. New: `DataPaths` subdir siblings; downloader saves-hash-on-200 / skips-on-304-when-hash-matches / redownloads-on-304-when-hash-mismatches / redownloads-when-hash-file-missing.

## Docs
`CLAUDE.md`, `README.md`, `docs/configuration.html`, `docs/installation.html`, and the `DataDirectory` XML doc updated for the new layout + verification.

## Migration
`-workDir` moves from the data-dir root to `work\`; the agent re-provisions `remoting/`/`workspace/` there once on upgrade (harmless; the old root files become inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)