### PR TITLE
docs: fact-check and trim the markdown + HTML docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,22 +12,24 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. ...
+2. ...
+3. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Environment**
+ - JenkinsAsService version: [e.g. 1.12]
+ - Install type: [MSI / portable archive]
+ - Windows version: [e.g. Windows 11 24H2 / Server 2022]
+ - JDK version: [e.g. Temurin 21]
+ - Jenkins controller version: [e.g. 2.479]
+ - Secret mode: [Dpapi / Tpm / CredentialManager / EnvironmentVariable / Unprotected]
+ - Connection method: [Auto / WebSocket / Https]
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
+**Logs**
+Relevant lines from `agent.log` (in `%ProgramData%\JenkinsAsService`) or the Windows Event Log (source `JenkinsAsService`). **Redact any secrets.**
 
 **Additional context**
 Add any other context about the problem here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `.slnx` builds the app + tests only; the installer has `Build=false` and mus
 - **Config POCOs:** `ServiceSettings.cs` (nested: `Connection`/`Secret`/`Agent`/`Hardening`/`Logging`/`Recovery`), `TelemetrySettings.cs`, `ConfigKeys.cs` (centralized section/key name constants — **use these, don't hardcode config strings**), `ConnectionMethod.cs`, `SecretMode.cs`, `DpapiScope.cs`
 - **Secrets:** `ISecretResolver.cs`/`SecretResolver.cs`, `SecretWriter.cs`, `UpdateSecretCommand.cs` (the `update-secret` CLI), `TpmSecretProtector.cs`, `AgentSecretFile.cs` (`-secret @<file>` off-argv), `CertificateThumbprintValidator.cs`
 - **Agent process:** `AgentProcessLauncher.cs` (the `IAgentProcessLauncher`/`IAgentProcess` seam — production wraps `System.Diagnostics.Process`; fakes drive the watchdog in tests), `AgentArgumentParser.cs`, `AgentTransport.cs` (pure transport-selection: `InitialMethod`/`Toggle`/`ShouldFallback`), `JavaPathResolver.cs`, `ServiceSettingsValidator.cs`
-- **Networking:** `IJarDownloader.cs`/`HttpJarDownloader.cs` (ETag conditional GET; downloads to a temp file + atomic move so a truncated download can't sit behind a valid ETag; records the jar's SHA-256 on download and re-verifies the cached jar on every 304 — a mismatch forces an unconditional re-download, so a tampered/corrupt cached jar is never launched. TOFU/local-integrity, not upstream authenticity — that's `Connection:ControllerCertThumbprint`), `IConnectivityChecker.cs`/`TcpConnectivityChecker.cs`
+- **Networking:** `IJarDownloader.cs`/`HttpJarDownloader.cs` (ETag conditional GET; temp-file + atomic move so a truncated download can't sit behind a valid ETag; records the jar's SHA-256 on download and re-verifies the cached jar on each 304 — a mismatch forces an unconditional re-download. TOFU/local-integrity, not upstream authenticity — that's `Connection:ControllerCertThumbprint`), `IConnectivityChecker.cs`/`TcpConnectivityChecker.cs`
 - **Hardening:** `ProcessMitigations.cs`, `EnvironmentSanitizer.cs`, `ConfigAclHardener.cs`, `EventLogSourceInstaller.cs`, `DataPaths.cs` (binary/data split)
 - **Other:** `Properties/AssemblyInfo.cs` (explicit assembly attributes — required for Codacy; do not delete)
 
@@ -85,7 +85,7 @@ Settings live under the `Jenkins` section of `appsettings.json`, grouped into su
 
 ## Testing
 
-xUnit + NSubstitute + FluentAssertions; **143 tests** currently (trust the runner, not any hard-coded number in docs). Test classes mirror units. Notable:
+xUnit + NSubstitute + FluentAssertions; **178 tests** currently (trust the runner, not any hard-coded number in docs). Test classes mirror units. Notable:
 - `SupervisionLoopTests` drives the full watchdog end-to-end via `FakeAgentProcess`/`FakeAgentProcessLauncher` with millisecond timing (restart-on-crash, give-up-and-stop, unreachable-never-gives-up).
 - `WatchdogTimingTests` — pure backoff-curve + max-retry unit tests.
 - `ConfigBindingTests` — binds the nested schema (incl. all three enums) and the shipped `appsettings.json` through real `IConfiguration`.
@@ -113,6 +113,6 @@ Add tests alongside new logic; run `dotnet test -c Release` and confirm green be
 
 ## Current state / open items
 
-- The hardening batch (PR #47 — secret-file ACL fix, watchdog resilience rewrite + process seam, installer security defaults, +20 tests, docs) is **merged to `main`**. A follow-up bug-review pass (PR #48, branch `hotfix/Fable`) fixed two shutdown races in the supervision loop (orphaned agent on stop-during-bring-up; `_agent` NRE) plus a Process-handle leak and an `update-secret --secret-file` delete crash.
+- Recent merges: hardening batch + shutdown-race fixes (PR #47/#48); full installer config coverage (PR #50, tag 1.7); Auto-transport fallback made to actually fire via `-noReconnect` (PR #57, tag 1.12); jar SHA-256 integrity check + `agent\`/`work\` data-dir split (PR #58).
 - **Deferred (by decision, not oversight):** release-artifact **code signing** (waiting on a free OSS cert; CI step not yet wired); **post-quantum at-rest encryption** (ML-KEM/ML-DSA declined — rotate secrets at the PQC transition instead); making plain-`http` a hard failure (still only warns); visible xUnit skips for TPM tests (needs a package or xUnit v3).
-- **Not yet done against real infra:** a real MSI install validating ACL/TPM-decrypt, and live WebSocket/`Auto`-fallback verification against a controller.
+- **Not yet verified against real infra:** a real MSI install validating ACL/TPM-decrypt, and live WebSocket/`Auto`-fallback against a controller.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,9 @@ dotnet publish src/JenkinsAsService `
     -p:EnableCompressionInSingleFile=true `
     -p:PublishReadyToRun=true
 
-# Optional: build MSI installer
+# Optional: build MSI installer (after publishing — it's excluded from the solution build)
 dotnet build src/JenkinsAsService.Installer -c Release `
-    -p:PublishDir=../../publish/x64/ -p:Version=1.0.0
+    -p:RestoreLockedMode=true -p:PublishDir=../../publish/x64/ -p:Version=1.0.0
 ```
 
 ### Project Structure
@@ -65,7 +65,7 @@ dotnet build src/JenkinsAsService.Installer -c Release `
 
 Use a descriptive prefix:
 
-- `feature/` — new functionality
+- `feat/` — new functionality
 - `fix/` — bug fixes
 - `chore/` — maintenance, dependency updates, CI changes
 - `docs/` — documentation only

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ JenkinsAsService replaces all of that with a proper Windows Service built on .NE
 - **Auto-start on boot** — runs under a least-privilege virtual service account (`NT SERVICE\Jenkins`), no interactive login required
 - **Event-driven watchdog** — detects agent death instantly (not polling), auto-recovers with exponential backoff (10s to 5min); a persistent crash-loop stops the service so Windows Service Recovery can act, while a merely-unreachable controller is retried indefinitely
 - **Secret protection** — TPM 2.0 hardware-backed key, DPAPI machine/user-scope encryption, Windows Credential Manager, environment variables, or plaintext
-- **Smart jar caching + integrity** — ETag-based conditional GET skips the download when `agent.jar` is unchanged; the jar's SHA-256 is recorded on download and re-verified on every reuse, so a tampered or corrupt cached jar is re-downloaded instead of launched
+- **Smart jar caching + integrity** — ETag conditional GET skips the download when `agent.jar` is unchanged; its SHA-256 is recorded on download and re-checked before reuse, so a tampered or corrupt cached jar is re-downloaded instead of launched
 - **HTTP resilience** — Polly-based retry, circuit breaker, and timeout on all HTTP calls
 - **Structured logging** — Serilog rolling file + Windows Event Log, with `ProcessId`/`MachineName` enrichment
 - **CLEF JSON mode** — machine-parseable compact log format for Seq, Datadog, or any log aggregator
 - **OpenTelemetry metrics** — opt-in OTLP export: restart counter, SEVERE event counter, .NET runtime metrics
 - **Secret redaction** — agent secrets are scrubbed from all log output
-- **143 unit tests** — xUnit + NSubstitute + FluentAssertions (incl. an end-to-end watchdog harness), CI on every push
+- **178 unit tests** — xUnit + NSubstitute + FluentAssertions (incl. an end-to-end watchdog harness), CI on every push
 - **6 security scans** — CodeQL (C# + Actions YAML), Semgrep, Gitleaks, PSScriptAnalyzer, Dependency Review, Trivy; all actions SHA-pinned
 - **Single-file deploy** — self-contained `.exe` with R2R, compression, and embedded PDB symbols
 - **Dual-arch releases** — x64 + x86 MSI installers, 7z/RAR archives, SHA256 checksums
@@ -74,7 +74,7 @@ The default install path is `C:\Program Files\Jenkins` (customizable in the UI).
 For automated deployments, use `msiexec` with public properties:
 
 ```powershell
-msiexec /i JenkinsAsService_1.0.4_x64.msi /qn `
+msiexec /i JenkinsAsService_x64.msi /qn `
     INSTALLFOLDER="D:\Jenkins" `
     JENKINS_URL="https://jenkins.example.com:8443" `
     JENKINS_SECRET="your-secret" `
@@ -185,8 +185,8 @@ Exports: `jenkins_agent_restarts_total`, `jenkins_agent_severe_events_total`, an
 **Windows Event Log:** Warnings and errors under source `JenkinsAsService` — crash evidence even when the file log is unavailable.
 
 ```powershell
-# Tail the log
-Get-Content 'C:\Program Files\Jenkins\agent.log' -Tail 50 -Wait
+# Tail the log (in the data folder, not the install folder)
+Get-Content 'C:\ProgramData\JenkinsAsService\agent.log' -Tail 50 -Wait
 
 # Check Event Log
 Get-EventLog -LogName Application -Source JenkinsAsService -Newest 20
@@ -256,7 +256,7 @@ dotnet build src/JenkinsAsService.Installer -c Release `
 - TLS 1.2+ enforced by default (.NET 10), with optional controller certificate pinning (`ControllerCertThumbprint`)
 - Secrets encrypted at rest (TPM 2.0 hardware-backed key, DPAPI machine/user scope, or CredMgr), redacted from all logs, and passed to the agent off the command line via `-secret @<file>` so they never appear in the process table
 - Least-privilege virtual service account, deny-by-default environment block for the agent child, and Win32 process-mitigation policies (no remote/low-IL/non-System32 DLL loads, extension-point injection disabled)
-- Binary/data separation: read-only binaries in `Program Files`, writable runtime data in `ProgramData` — a malicious pipeline running under the agent can't overwrite the service `.exe`. Within the data folder the cached `agent.jar` (+ SHA-256) sits in `agent\`, isolated from the build `work\` dir, and is integrity-checked before each launch so a build step can't swap the binary the watchdog runs
+- Binary/data separation: read-only binaries in `Program Files`, writable runtime data in `ProgramData` — a malicious pipeline can't overwrite the service `.exe`. The cached `agent.jar` (+ SHA-256) lives in an `agent\` subfolder isolated from the build `work\` dir and is integrity-checked before each launch, so a build step can't swap the binary the watchdog runs
 - Deterministic builds with locked NuGet restore and embedded PDB symbols
 - CycloneDX **SBOM** generated in CI and attached to every release (with SHA-256 checksum)
 - Unit tests run on every push and PR

--- a/Security.md
+++ b/Security.md
@@ -81,10 +81,11 @@ JenkinsAsService handles sensitive data (Jenkins agent secrets) and runs as a pr
 
 ### Secret Protection
 
-Secrets are never stored in plaintext by default (MSI installer defaults to `EnvironmentVariable` mode). Four protection modes are available:
+Secrets are never stored in plaintext by default (the MSI installer defaults to `Dpapi`). Five protection modes are available, strongest first:
 
 | Mode | Mechanism | Risk if host is compromised |
 |---|---|---|
+| `Tpm` | TPM-bound, non-exportable RSA key (Platform Crypto Provider) | Usable only on this machine's TPM, by a process that can access the key |
 | `Dpapi` | Machine-scoped DPAPI encryption | Decryptable by any process on the same machine |
 | `CredentialManager` | Windows Credential Manager vault | Accessible to processes running as the same user |
 | `EnvironmentVariable` | Machine-level environment variable | Readable by any process on the machine |
@@ -92,7 +93,7 @@ Secrets are never stored in plaintext by default (MSI installer defaults to `Env
 
 ### Secret Redaction
 
-Agent secrets are scrubbed from all log output (file and Event Log) before being written. The redaction logic replaces any occurrence of the secret value with `[REDACTED]`.
+Agent secrets are scrubbed from all log output (file and Event Log) before being written. The redaction logic replaces any occurrence of the resolved secret with `*****`.
 
 ### Network Security
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -74,7 +74,7 @@
 &#x251C;&#x2500;&#x2500; src/
 &#x2502;   &#x2514;&#x2500;&#x2500; JenkinsAsService.Installer/    # WiX v5 MSI installer project
 &#x251C;&#x2500;&#x2500; tests/
-&#x2502;   &#x2514;&#x2500;&#x2500; JenkinsAsService.Tests/        # 59 xUnit unit tests
+&#x2502;   &#x2514;&#x2500;&#x2500; JenkinsAsService.Tests/        # xUnit unit-test suite
 &#x251C;&#x2500;&#x2500; .github/
 &#x2502;   &#x2514;&#x2500;&#x2500; workflows/                     # CI/CD: build, test, 6 security scans, release
 &#x251C;&#x2500;&#x2500; README.md
@@ -303,7 +303,7 @@
 
     <h2 id="testing">Testing</h2>
 
-    <p>143 unit tests across 19 test classes in <code>tests/JenkinsAsService.Tests/</code> (count grows with the suite &mdash; trust the test runner over this page). One class per unit under test:</p>
+    <p>178 unit tests across 20 test classes in <code>tests/JenkinsAsService.Tests/</code> (count grows with the suite &mdash; trust the test runner over this page). One class per unit under test:</p>
 
     <div class="table-wrap">
       <table>

--- a/docs/ci-cd.html
+++ b/docs/ci-cd.html
@@ -57,7 +57,7 @@
       <li><strong>Purpose:</strong> Full end-to-end build validation on every push/PR to <code>main</code></li>
       <li><strong>Runner:</strong> <code>windows-latest</code></li>
       <li><strong>Steps:</strong> Setup .NET 10 &rarr; <code>dotnet restore -p:RestoreLockedMode=true</code> &rarr; <code>dotnet test</code> &rarr; CycloneDX SBOM (uploaded as artifact) &rarr; optimized publish (win-x64 + win-x86) &rarr; WiX v5 MSI build (both architectures, <code>Version=0.0.0</code>)</li>
-      <li><strong>Tests:</strong> 143 unit tests (xUnit + NSubstitute + FluentAssertions)</li>
+      <li><strong>Tests:</strong> 178 unit tests (xUnit + NSubstitute + FluentAssertions)</li>
       <li><strong>Note:</strong> Mirrors every compile and package step in the release workflow so failures surface on PRs, not at release time.</li>
     </ul>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,7 +98,7 @@
           </tr>
           <tr>
             <td>Testing</td>
-            <td>143 unit tests (xUnit + NSubstitute + FluentAssertions)</td>
+            <td>178 unit tests (xUnit + NSubstitute + FluentAssertions)</td>
           </tr>
           <tr>
             <td>CI/CD</td>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -468,7 +468,7 @@ sc.exe start Jenkins</code></pre>
 
     <div class="callout callout-note">
       <div class="callout-title">Low-privilege account prerequisites</div>
-      <p>A virtual / low-privilege account cannot create the Event Log source or write into <code>Program Files</code>. When not using the MSI, run <code>update-secret --silent</code> from an elevated prompt once (it pre-creates the Event Log source), and grant the account Modify on the install folder so it can write logs and download <code>agent.jar</code>. The service falls back to file-only logging if the Event Log source is unavailable.</p>
+      <p>A virtual / low-privilege account cannot create the Event Log source. When not using the MSI, run <code>update-secret --silent</code> from an elevated prompt once (it pre-creates the Event Log source and writes <code>appsettings.json</code>). Runtime artifacts (logs, <code>agent.jar</code>, work dir) go to the separate writable data folder <code>%ProgramData%\JenkinsAsService</code>, which the service creates itself &mdash; no write access to <code>Program Files</code> is required at runtime. The service falls back to file-only logging if the Event Log source is unavailable.</p>
     </div>
 
     <p>To configure secret protection and harden the config ACL, run the CLI (elevated) before starting:</p>

--- a/docs/overview.html
+++ b/docs/overview.html
@@ -82,7 +82,7 @@
       <li><strong>Dual logging</strong> &mdash; Serilog rolling file (<code>agent.log</code> or <code>agent.clef</code>) plus Windows Event Log</li>
       <li><strong>Secret redaction</strong> &mdash; agent secrets scrubbed from all log output</li>
       <li><strong>Single-file deploy</strong> &mdash; self-contained .exe with R2R, compression, and embedded PDB</li>
-      <li><strong>143 unit tests</strong> &mdash; xUnit + NSubstitute + FluentAssertions, CI on every push</li>
+      <li><strong>178 unit tests</strong> &mdash; xUnit + NSubstitute + FluentAssertions, CI on every push</li>
     </ul>
 
     <h2 id="how-it-works">How It Works</h2>


### PR DESCRIPTION
Review pass over the markdown and HTML docs — fact-checked against the code and workflows, corrected wrong claims, and trimmed verbosity. No code changes.

## Factual fixes

| File(s) | Was | Now |
|---|---|---|
| `Security.md` | MSI default `EnvironmentVariable` | **`Dpapi`** (matches the installer) |
| `Security.md` | "Four modes" — table missing TPM | **Five**, TPM row added (strongest-first) |
| `Security.md` | redaction `[REDACTED]` | `*****` (the actual `SecretRedaction` const) |
| `README.md` | tail `C:\Program Files\Jenkins\agent.log` | `C:\ProgramData\JenkinsAsService\agent.log` |
| README + 5 HTML pages | **143** tests (one said **59**) | **178** (runner ground-truth); class count 19 → 20 |
| `installation.html` | "grant Modify on install folder so it can write logs and download agent.jar" | corrected — those go to `%ProgramData%`; no runtime `Program Files` write |
| `bug_report.md` | web-app boilerplate (OS: iOS / Browser: chrome) | Windows-service fields (version, install type, Windows/JDK/Jenkins version, secret mode, transport, logs) |
| `CONTRIBUTING.md` | branch prefix `feature/` | `feat/` (matches commit convention); added `-p:RestoreLockedMode=true` to installer build |

## Cleanup
- `CLAUDE.md`: refreshed the stale **"Current state"** section (was citing PR #47/#48; now #50/#57/#58 + tags), tightened the jar-downloader note, bumped the test count.
- `README.md`: trimmed two over-verbose bullets; genericized the `msiexec` example filename.

## Verified correct (no change)
- **"6 security scans"** — `osv-scanner.yml` is the Trivy workflow (`name: Trivy`, calls `trivy-reusable.yml`); no separate OSV tool, so the count and list are accurate.
- `CODE_OF_CONDUCT.md` left as-is (standard Contributor Covenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)