### PR TITLE
docs: add privacy policy and link it from docs + README

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,124 @@
+# Privacy Policy
+
+This policy explains what data **JenkinsAsService** — both the installed Windows Service and the
+[documentation website](https://jenkinsasservice.machlev.org) — does and does not collect.
+
+JenkinsAsService is a self-hosted, local-first tool. **The project collects nothing about you.**
+There are no accounts, no analytics, and no "phone home." Everything the service handles stays on the
+machine you install it on, unless *you* explicitly configure it to send data somewhere you control.
+
+## Summary
+
+- The **service** runs entirely on your machine and sends no data to the project or any third party.
+- **Telemetry is opt-in and off by default.** When you enable it, metrics go only to an endpoint you configure.
+- The **documentation website** and **GitHub repository** are static/standard hosting. The third parties
+  involved — Cloudflare and GitHub (hosting/proxy), plus jsDelivr and Shields.io (a diagram CDN and a
+  badge service) — are infrastructure, not operated by this project, and none receive anything beyond the
+  normal request metadata (such as your IP) inherent to loading a web page.
+
+## The Software (JenkinsAsService Windows Service)
+
+### Data stored locally
+
+The service reads and writes the following, all of which stay on the host machine and are never
+transmitted to the project:
+
+- **Configuration** (`appsettings.json`, in the install folder) — your Jenkins controller URL, agent
+  name, and the protected secret value. See [Secrets](#secrets) below.
+- **The secret file** (`.agent-secret`, in the data folder) — an ACL-restricted file created only while
+  the agent runs and deleted on service stop.
+- **Logs** (`agent.log` or `agent.clef`, in the data folder) — service and Java-agent output. These may
+  contain your machine's hostname, the configured agent name, exit codes, and controller connection
+  messages. Agent secrets are [redacted](#secrets) before anything is written.
+- **The cached agent binary** (`agent.jar` plus `.etag`/`.sha256` sidecars, under `agent\`) and the
+  Jenkins work directory (under `work\`).
+
+The install folder lives in `Program Files` (read-only to the service account) and the writable data
+lives in `%ProgramData%\JenkinsAsService` — see the [Configuration reference](https://jenkinsasservice.machlev.org/configuration.html).
+
+### Network connections the service makes
+
+The service opens a network connection in exactly three cases, and no others — there is no update check,
+no crash reporting, and no usage analytics:
+
+1. **Your Jenkins controller** — before each launch it makes a TCP connectivity check to the configured
+   host/port, then downloads `agent.jar` over HTTP(S) from `<your-controller>/jnlpJars/agent.jar`
+   (skipped when the cached copy is current). The launched Java agent then connects to that same
+   controller to do its job. This is the controller **you** configure; what it logs is governed by your
+   own Jenkins instance, not by this project.
+2. **An OpenTelemetry endpoint — only if you turn it on.** Telemetry is disabled by default
+   (`Telemetry:Enabled = false`). When enabled, the service exports **metrics only** over OTLP to the
+   `OtlpEndpoint` you specify. The exported data is limited to counters and runtime gauges —
+   `jenkins_agent_restarts_total`, `jenkins_agent_severe_events_total`, and standard .NET runtime metrics
+   (GC, threads, memory). **No secrets, log contents, or personal data are included**, and the
+   destination is entirely under your control.
+
+That is the complete list. The service never contacts any server operated by the project or its author.
+
+### Secrets
+
+Your Jenkins agent secret is encrypted at rest (TPM, DPAPI, or Windows Credential Manager — or stored as
+an environment-variable name / plaintext if you choose those modes), passed to the agent off the process
+command line via `-secret @<file>`, and redacted (`*****`) from all log output. The project never
+receives, transmits, or has any access to your secret. See the
+[Security Policy](https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md) for details.
+
+## The Documentation Website (jenkinsasservice.machlev.org)
+
+The docs site is a **static** site. It sets no cookies, runs no analytics or tracking scripts, has no
+forms or accounts, and collects nothing itself. Three third parties are involved in serving it:
+
+- **Cloudflare** provides DNS and proxies the custom domain (`jenkinsasservice.machlev.org`) in front of
+  the origin. Because traffic is proxied through Cloudflare, it terminates TLS and can see your IP address
+  and request metadata, per the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/).
+- **GitHub Pages** is the origin that hosts the site behind Cloudflare. GitHub may log request metadata as
+  described in the
+  [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
+  and [GitHub Pages data collection](https://docs.github.com/en/pages/getting-started-with-github-pages/what-is-github-pages#data-collection).
+- **jsDelivr** (a public CDN) serves the Mermaid diagram library on the pages that render diagrams
+  (Overview, Architecture, Configuration). Loading it exposes your IP address to jsDelivr, per the
+  [jsDelivr Privacy Policy](https://www.jsdelivr.com/terms/privacy-policy-jsdelivr-net).
+
+## The GitHub Repository
+
+The source code, issues, and release downloads are hosted on **GitHub**. Browsing the repository, cloning
+it, and downloading release artifacts all involve GitHub, which may log your IP address and request
+metadata per the
+[GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+This is standard GitHub behavior, not something this project controls or adds to.
+
+The README displays status badges. Most (License, .NET, Platform, Docs) are **self-hosted inside this
+repository** and involve no third party. Two are served by GitHub (the Build and CodeQL workflow-status
+badges), and one — the *Latest Release* badge — is generated by the **[Shields.io](https://shields.io)**
+service, which sees the request for that image. When you view the README **on github.com**, GitHub
+proxies all external badge images through its own [Camo image proxy](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls),
+so your IP goes to GitHub rather than directly to Shields.io. If the README is rendered somewhere else,
+those image requests can reach the badge host directly.
+
+## Third Parties at a Glance
+
+| Party | When it's involved | What it may receive | Their policy |
+|---|---|---|---|
+| Cloudflare (DNS + proxy) | Visiting the docs site | IP address, request metadata (proxied traffic) | [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/) |
+| GitHub (repo + Pages) | Browsing/cloning the repo, downloading releases, or the docs site | IP address, request logs | [GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) |
+| Shields.io | Viewing the README's *Latest Release* badge (proxied via GitHub Camo when viewed on github.com) | IP address | [Shields.io](https://shields.io) |
+| jsDelivr (CDN) | Viewing diagram pages on the docs site | IP address | [jsDelivr Privacy Policy](https://www.jsdelivr.com/terms/privacy-policy-jsdelivr-net) |
+| Your Jenkins controller | Running the service | Connections from the service and Java agent | Your organization's policy |
+| Your OTLP endpoint | Only if telemetry is enabled | The metrics listed above | Your configuration |
+
+## Changes to This Policy
+
+This policy may be updated as the software evolves. The **Last updated** date below reflects the latest
+revision, and material changes are noted in the release notes.
+
+## Contact
+
+For privacy questions, open an issue on the
+[GitHub repository](https://github.com/EliorMachlev/JenkinsAsService/issues). For anything sensitive, use
+the private contact channel described in the
+[Security Policy](https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md). Please never
+include secrets or credentials in a report.
+
+---
+
+_Last updated: 2026-07-12_

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ dotnet build src/JenkinsAsService.Installer -c Release `
 
 See [Security Policy](Security.md) for vulnerability reporting.
 
+## Privacy
+
+JenkinsAsService is local-first and collects nothing about you: the service runs entirely on your machine, telemetry is opt-in and off by default, and there is no update check or "phone home." See the [Privacy Policy](PRIVACY.md) for what the service and the docs site do and don't collect.
+
 ## License
 
 [BSD 3-Clause](LICENSE)

--- a/docs/api-reference.html
+++ b/docs/api-reference.html
@@ -35,7 +35,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -36,7 +36,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/ci-cd.html
+++ b/docs/ci-cd.html
@@ -35,7 +35,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -36,7 +36,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -35,7 +35,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/overview.html
+++ b/docs/overview.html
@@ -36,7 +36,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -35,7 +35,8 @@
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/CONTRIBUTING.md" target="_blank">Contributing</a></li>
       <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/LICENSE" target="_blank">BSD-3-Clause License</a></li>
-      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>    </ul>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/Security.md" target="_blank">Security Policy</a></li>
+      <li><a href="https://github.com/EliorMachlev/JenkinsAsService/blob/main/PRIVACY.md" target="_blank">Privacy Policy</a></li>    </ul>
     <div class="sidebar-footer">
       <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme"></button>
       <a href="https://github.com/EliorMachlev/JenkinsAsService" class="github-link" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary

Adds a privacy policy for JenkinsAsService and references it wherever the other project policies are linked. **Docs-only — no code changes.**

## What's included

- **`PRIVACY.md`** (repo root, alongside `Security.md`) — grounded in the actual code:
  - **The service** is local-first: no accounts, analytics, or phone-home. The only outbound connections are to your *own* Jenkins controller (TCP check + jar download) and an **opt-in, off-by-default** OpenTelemetry OTLP endpoint you configure (metrics only — no secrets, log contents, or PII). Verified against the code: the sole `HttpClient` is the jar downloader; there is no update check.
  - **The docs site & repo** third parties are documented: **Cloudflare** (DNS/proxy for the custom domain), **GitHub** (Pages hosting + repo browsing/cloning/release downloads), **jsDelivr** (Mermaid diagram CDN), and **Shields.io** (the *Latest Release* README badge — noting GitHub's Camo proxy shields your IP when viewed on github.com). Includes a third-parties-at-a-glance table.
- **Docs sidebar** — a "Privacy Policy" link added to the Community section of all 8 HTML pages (matching the existing Security/License/Contributing links).
- **README** — a new Privacy section linking to `PRIVACY.md`.

## Verification

- All 8 edited HTML pages pass tag-balance checks.
- Facts (network behavior, telemetry default, secret handling, badge sources, hosting chain) cross-checked against the source and confirmed with the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)