### PR TITLE
fix(config): emit the full schema on fresh install

### DIFF
--- a/src/JenkinsAsService/SecretWriter.cs
+++ b/src/JenkinsAsService/SecretWriter.cs
@@ -43,6 +43,14 @@ public static class SecretWriter
         {
             ConfigAclHardener.Harden(configPath, serviceAccount);
         }
+
+        // Emit every schema key on a fresh install. BuildJenkinsSection only sets the keys this writer knows,
+        // so newer POCO keys (e.g. Agent:LaunchInInteractiveSession) and the whole Telemetry section would
+        // otherwise be absent until an MSI upgrade ran the reconcile. Reconcile here to the same POCO schema
+        // the upgrade path uses, so fresh-install output matches upgrade output and can't drift as the schema
+        // grows. Adds missing keys at their defaults; the secret is an in-schema value (preserved verbatim),
+        // and File.Replace keeps the hardened DACL just applied.
+        NormalizeConfig(basePath);
     }
 
     /// <summary>

--- a/tests/JenkinsAsService.Tests/SecretWriterTests.cs
+++ b/tests/JenkinsAsService.Tests/SecretWriterTests.cs
@@ -175,6 +175,43 @@ public class SecretWriterTests : IDisposable
     }
 
     [Fact]
+    public void WriteConfig_fresh_install_emits_every_schema_key()
+    {
+        // A fresh install has no existing file: the hand-built section must still be reconciled to the full
+        // POCO schema, so newer keys the writer doesn't set (Agent:LaunchInInteractiveSession) and the whole
+        // Telemetry section are present at their defaults — matching what an MSI upgrade would produce.
+        SecretWriter.WriteConfig(_tempDir, "fresh-secret", SecretMode.Unprotected,
+            "https://jenkins:8443", "agent-x", @"C:\jdk");
+
+        var root = ReadConfig().RootElement;
+        var jenkins = root.GetProperty("Jenkins");
+
+        var interactive = jenkins.GetProperty("Agent").GetProperty("LaunchInInteractiveSession");
+        interactive.GetProperty("Enabled").GetBoolean().Should().BeFalse("default is off");
+        interactive.GetProperty("LocalSystemOnly").GetBoolean().Should().BeTrue("default is LocalSystem-gated");
+
+        root.TryGetProperty("Telemetry", out _).Should().BeTrue("the Telemetry section is part of the schema");
+
+        // The reconcile must not disturb the values the writer set — especially the secret.
+        jenkins.GetProperty("Secret").GetProperty("Value").GetString().Should().Be("fresh-secret");
+        jenkins.GetProperty("Connection").GetProperty("Url").GetString().Should().Be("https://jenkins:8443");
+        jenkins.GetProperty("Connection").GetProperty("AgentName").GetString().Should().Be("agent-x");
+    }
+
+    [Fact]
+    public void WriteConfig_fresh_install_output_binds_and_needs_no_further_reconcile()
+    {
+        // The fresh-install file should already be schema-complete: a follow-up NormalizeConfig must be a
+        // no-op (nothing added, nothing removed), proving the writer and the upgrade path now agree.
+        SecretWriter.WriteConfig(_tempDir, "secret", SecretMode.Unprotected, "https://jenkins:8443", null, null);
+
+        var (added, removed) = SecretWriter.NormalizeConfig(_tempDir);
+
+        added.Should().BeEmpty("fresh install already emitted every schema key");
+        removed.Should().BeEmpty("fresh install emitted no keys outside the schema");
+    }
+
+    [Fact]
     public void SetDataDirectory_sets_field_and_preserves_other_fields_and_sections()
     {
         const string existingJson =


### PR DESCRIPTION
## What & why

A fresh MSI install's `appsettings.json` was **missing schema keys** that the config writer doesn't explicitly set — most visibly `Agent:LaunchInInteractiveSession` (added in #69) and the entire `Telemetry` section.

`SecretWriter.BuildJenkinsSection` hand-builds the `Jenkins` section from an explicit key list, so any POCO key it doesn't enumerate never lands on disk. Those keys only appeared after an **MSI upgrade**, whose `UpgradeConfig` CA runs the POCO-derived reconcile (`ServiceSettingsNormalizer`). Result: fresh install and upgrade produced **different files** for the same build, and a fresh install could never show newer optional settings.

## The fix

Reconcile the freshly written file to the same POCO schema as the final step of `WriteConfig`, reusing the existing, already-tested `SecretWriter.NormalizeConfig`:

```csharp
NormalizeConfig(basePath);
```

- Adds **every** missing schema key at its POCO default → fresh-install output now equals upgrade output, and it **can't drift again** as the schema grows (no more hand-maintained key list to keep in sync).
- **Secret preserved** — it's an in-schema value, kept verbatim by the reconcile.
- **Hardened ACL preserved** — `NormalizeConfig` rewrites atomically via `File.Replace`, which keeps the destination DACL that `ConfigAclHardener` just applied.
- Top-level schema is exactly `{Jenkins, Telemetry}` (matches the shipped `appsettings.json`), so no legitimate section is pruned.

## Fresh-install vs. upgrade — now symmetric

| Path | Before | After |
|---|---|---|
| Fresh install (`WriteConfig`) | writer-known keys only | **full schema** |
| MSI upgrade (`--upgrade` reconcile) | full schema | full schema (unchanged) |

## Testing

- Full suite **196/196** (2 new tests), `dotnet build -c Release` 0 errors.
- `WriteConfig_fresh_install_emits_every_schema_key` — fresh output contains the `LaunchInInteractiveSession` block (`Enabled=false`, `LocalSystemOnly=true`) and the `Telemetry` section, and still carries the secret/URL/agent name the writer set.
- `WriteConfig_fresh_install_output_binds_and_needs_no_further_reconcile` — a follow-up `NormalizeConfig` is a **no-op** (nothing added, nothing removed), proving the writer and the upgrade path now agree.
- Existing `SecretWriterTests` (secret modes, field preservation, bad-type resilience) stay green — the reconcile preserves all in-schema values.

## Notes

- Behavioural fix for **future** installs only; an already-installed `appsettings.json` is not rewritten retroactively (add the key by hand, or it's filled in on the next upgrade).
- `SetDataDirectory` / `MergeConfig` (the installer's other config CAs) are untouched — they keep their surgical preserve-everything semantics and run after `WriteConfig`, so the reconciled keys survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
